### PR TITLE
feat: proper settings page + library folders (closes #12)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-settings-page.md
+++ b/docs/superpowers/plans/2026-04-24-settings-page.md
@@ -1,0 +1,2277 @@
+# Settings Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a proper settings experience as a top-level category, fix issue #12 (user-selectable library folders), consolidate cross-cutting preferences into a single versioned store with one-shot migration, and introduce a Zune-style boot/update splash.
+
+**Architecture:** Main-process `preferences.js` module is the single source of truth for `preferences.json`. Renderer reads via IPC, subscribes to changes, and owns a new `SettingsView` with drill-down navigation. Library folder paths move from hardcoded (`~/Music`, `~/Movies`, `~/Pictures`) to preferences-driven. Rescan deltas are computed from old/new folder lists rather than re-scanning unchanged folders. BootSplash overlays the renderer once per install/upgrade.
+
+**Tech Stack:** Electron (Node 18+ in main, Chromium in renderer), plain JS (no TS), `node:test` for unit tests on main-process modules, manual acceptance testing for renderer UI.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-settings-page-design.md`
+
+**Branch:** `feat/settings-page`
+
+---
+
+## File structure
+
+**Create:**
+- `src/main/preferences.js` — preferences store module (singleton). API: `load()`, `get(dotPath)`, `update(patch)`, `reset(section?)`, `subscribe(cb)`.
+- `src/main/preferences-migrations.js` — `detectInstallType()` + `importLegacyFiles()` + schema version migrations.
+- `src/shared/path-utils.js` — pure path helpers (`isUnderPrefix`, `isUnderAnyPrefix`, `computeAddedPaths`, `computeRemovedPaths`). Shared between main and renderer, testable.
+- `src/assets/js/settings-view.js` — `SettingsView` class, drill stack, per-page renderers.
+- `src/assets/js/boot-splash.js` — `BootSplash` class (Zune-style vertical-bar animation).
+- `tests/preferences.test.js`
+- `tests/preferences-migrations.test.js`
+- `tests/path-utils.test.js`
+
+**Modify:**
+- `package.json` — add `test` script.
+- `src/main/main.js` — wire preferences init into boot sequence; IPC handlers for preferences, pick-folder, clear-metadata-cache, clear-device-cache, get-app-version.
+- `src/main/preload.js` — new `electronAPI.preferences*` + `pickFolder` + `onFirstRun` + cache-clear helpers.
+- `src/main/podcast-manager.js` — read `downloadDirectory` from central preferences; remove local storage for this one field.
+- `src/assets/js/renderer.js` — register 'settings' category; read library folders from preferences in `scanMediaFiles`; mount `SettingsView` + `BootSplash`; behavior-change toast trigger.
+- `src/renderer/index.html` — add settings menu item; add boot-splash root element.
+- `src/assets/css/styles.css` — settings drill-list styles; boot-splash styles.
+
+**Delete (at runtime — not in repo):**
+- `userData/pull-destination.json` (removed by migration after successful import)
+
+---
+
+## Task 1: Bootstrap test infrastructure
+
+**Files:**
+- Modify: `package.json`
+- Create: `tests/sanity.test.js`
+
+- [ ] **Step 1: Add test script to `package.json`**
+
+Open `package.json`. Add to the `scripts` block:
+
+```json
+"test": "node --test tests/"
+```
+
+- [ ] **Step 2: Create `tests/sanity.test.js`**
+
+```javascript
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('sanity: node:test runs', () => {
+  assert.equal(1 + 1, 2);
+});
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `npm test`
+Expected: `# pass 1` with exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json tests/sanity.test.js
+git commit -m "chore: add node:test infrastructure"
+```
+
+---
+
+## Task 2: path-utils shared module + tests
+
+**Files:**
+- Create: `src/shared/path-utils.js`
+- Create: `tests/path-utils.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+`tests/path-utils.test.js`:
+
+```javascript
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isUnderPrefix,
+  isUnderAnyPrefix,
+  computeAddedPaths,
+  computeRemovedPaths,
+} = require('../src/shared/path-utils');
+
+test('isUnderPrefix: exact match is under itself', () => {
+  assert.equal(isUnderPrefix('/a/b', '/a/b'), true);
+});
+
+test('isUnderPrefix: sub-path is under prefix', () => {
+  assert.equal(isUnderPrefix('/a/b/c', '/a/b'), true);
+});
+
+test('isUnderPrefix: sibling is not under', () => {
+  assert.equal(isUnderPrefix('/a/bc', '/a/b'), false);
+});
+
+test('isUnderPrefix: parent is not under child', () => {
+  assert.equal(isUnderPrefix('/a', '/a/b'), false);
+});
+
+test('isUnderPrefix: trailing slash on prefix normalized', () => {
+  assert.equal(isUnderPrefix('/a/b/c', '/a/b/'), true);
+});
+
+test('isUnderAnyPrefix: matches one of several', () => {
+  assert.equal(isUnderAnyPrefix('/music/rock', ['/other', '/music']), true);
+});
+
+test('isUnderAnyPrefix: empty list returns false', () => {
+  assert.equal(isUnderAnyPrefix('/a', []), false);
+});
+
+test('computeAddedPaths: returns new list minus old', () => {
+  assert.deepEqual(computeAddedPaths(['/a'], ['/a', '/b']), ['/b']);
+});
+
+test('computeRemovedPaths: returns old list minus new', () => {
+  assert.deepEqual(computeRemovedPaths(['/a', '/b'], ['/a']), ['/b']);
+});
+
+test('computeAddedPaths: no changes returns empty', () => {
+  assert.deepEqual(computeAddedPaths(['/a'], ['/a']), []);
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `npm test -- tests/path-utils.test.js`
+Expected: FAIL — `Cannot find module '../src/shared/path-utils'`.
+
+- [ ] **Step 3: Implement the module**
+
+`src/shared/path-utils.js`:
+
+```javascript
+function normalize(p) {
+  if (!p) return p;
+  return p.endsWith('/') || p.endsWith('\\') ? p.slice(0, -1) : p;
+}
+
+function isUnderPrefix(p, prefix) {
+  const np = normalize(p);
+  const npr = normalize(prefix);
+  if (np === npr) return true;
+  return np.startsWith(npr + '/') || np.startsWith(npr + '\\');
+}
+
+function isUnderAnyPrefix(p, prefixes) {
+  return prefixes.some((pref) => isUnderPrefix(p, pref));
+}
+
+function computeAddedPaths(oldList, newList) {
+  const oldSet = new Set(oldList.map(normalize));
+  return newList.filter((p) => !oldSet.has(normalize(p)));
+}
+
+function computeRemovedPaths(oldList, newList) {
+  const newSet = new Set(newList.map(normalize));
+  return oldList.filter((p) => !newSet.has(normalize(p)));
+}
+
+module.exports = {
+  isUnderPrefix,
+  isUnderAnyPrefix,
+  computeAddedPaths,
+  computeRemovedPaths,
+};
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npm test`
+Expected: all 10 path-utils tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/path-utils.js tests/path-utils.test.js
+git commit -m "feat(shared): add path-utils module for prefix matching and list deltas"
+```
+
+---
+
+## Task 3: Preferences module — load + defaults
+
+**Files:**
+- Create: `src/main/preferences.js`
+- Create: `tests/preferences.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+`tests/preferences.test.js`:
+
+```javascript
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+function freshModule() {
+  delete require.cache[require.resolve('../src/main/preferences')];
+  return require('../src/main/preferences');
+}
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prefs-test-'));
+});
+
+test('load: missing file writes defaults', async () => {
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.equal(store.version, 1);
+  assert.deepEqual(store.library.music, ['/Users/test/Music']);
+  assert.deepEqual(store.library.videos, ['/Users/test/Movies']);
+  assert.deepEqual(store.library.pictures, ['/Users/test/Pictures']);
+  assert.equal(store.library.scanDesktopAndDownloads, false);
+
+  const raw = await fs.readFile(path.join(tmpDir, 'preferences.json'), 'utf-8');
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.version, 1);
+});
+
+test('load: valid existing file returned as-is', async () => {
+  await fs.writeFile(
+    path.join(tmpDir, 'preferences.json'),
+    JSON.stringify({
+      version: 1,
+      library: { music: ['/a'], videos: ['/b'], pictures: ['/c'], scanDesktopAndDownloads: true },
+      sync: { pullDestination: '/pull' },
+      podcasts: { downloadDirectory: '/pods' },
+      meta: { installedVersion: '1.4.0', firstRunAt: '2026-01-01T00:00:00Z' },
+    })
+  );
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/a']);
+  assert.equal(store.library.scanDesktopAndDownloads, true);
+  assert.equal(store.sync.pullDestination, '/pull');
+});
+
+test('load: missing nested keys get defaults merged in', async () => {
+  await fs.writeFile(
+    path.join(tmpDir, 'preferences.json'),
+    JSON.stringify({ version: 1, library: { music: ['/a'] } })
+  );
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/a']);
+  assert.deepEqual(store.library.videos, ['/Users/test/Movies']);
+  assert.equal(store.library.scanDesktopAndDownloads, false);
+  assert.equal(store.sync.pullDestination, null);
+});
+
+test('get: returns value at dot path', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(prefs.get('library.music'), ['/Users/test/Music']);
+  assert.equal(prefs.get('library.scanDesktopAndDownloads'), false);
+  assert.equal(prefs.get('sync.pullDestination'), null);
+  assert.equal(prefs.get('nonexistent.path'), undefined);
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npm test -- tests/preferences.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+`src/main/preferences.js`:
+
+```javascript
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const FILENAME = 'preferences.json';
+const SCHEMA_VERSION = 1;
+
+let state = null;
+let storeDir = null;
+let subscribers = [];
+let writeTimer = null;
+
+function defaultPrefs(defaultHome) {
+  return {
+    version: SCHEMA_VERSION,
+    library: {
+      music: [path.join(defaultHome, 'Music')],
+      videos: [path.join(defaultHome, 'Movies')],
+      pictures: [path.join(defaultHome, 'Pictures')],
+      scanDesktopAndDownloads: false,
+    },
+    sync: { pullDestination: null },
+    podcasts: { downloadDirectory: null },
+    meta: {
+      installedVersion: null,
+      firstRunAt: null,
+      behaviorChangeToastShown: false,
+    },
+  };
+}
+
+function deepMergeDefaults(loaded, defaults) {
+  const out = {};
+  for (const key of Object.keys(defaults)) {
+    const dv = defaults[key];
+    const lv = loaded ? loaded[key] : undefined;
+    if (lv === undefined) {
+      out[key] = dv;
+    } else if (dv && typeof dv === 'object' && !Array.isArray(dv)) {
+      out[key] = deepMergeDefaults(lv, dv);
+    } else {
+      out[key] = lv;
+    }
+  }
+  return out;
+}
+
+async function readFileSafe(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    try { await fs.rename(filePath, filePath + '.bad'); } catch {}
+    return null;
+  }
+}
+
+async function writeNow() {
+  if (!state || !storeDir) return;
+  const filePath = path.join(storeDir, FILENAME);
+  const copy = { ...state };
+  delete copy.__defaultHome;
+  const raw = JSON.stringify(copy, null, 2);
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, raw);
+  await fs.rename(tmp, filePath);
+}
+
+function scheduleWrite(ms = 200) {
+  if (writeTimer) clearTimeout(writeTimer);
+  writeTimer = setTimeout(() => {
+    writeTimer = null;
+    writeNow().catch((err) => console.error('preferences: write failed', err));
+  }, ms);
+}
+
+async function load(userDataDir, { defaultHome }) {
+  storeDir = userDataDir;
+  const filePath = path.join(storeDir, FILENAME);
+  const loaded = await readFileSafe(filePath);
+  const defaults = defaultPrefs(defaultHome);
+  if (loaded === null) {
+    state = defaults;
+    await writeNow();
+  } else {
+    state = deepMergeDefaults(loaded, defaults);
+  }
+  state.__defaultHome = defaultHome;
+  return state;
+}
+
+function get(dotPath) {
+  if (!state) return undefined;
+  const parts = dotPath.split('.');
+  let cur = state;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+module.exports = { load, get, SCHEMA_VERSION };
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npm test`
+Expected: all 4 preferences tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/preferences.js tests/preferences.test.js
+git commit -m "feat(preferences): add load/get with schema defaults and deep-merge"
+```
+
+---
+
+## Task 4: Preferences module — update + subscribe + reset + malformed recovery
+
+**Files:**
+- Modify: `src/main/preferences.js`
+- Modify: `tests/preferences.test.js`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/preferences.test.js`:
+
+```javascript
+test('update: deep merges patch and persists', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({ library: { music: ['/new'] } });
+  assert.deepEqual(prefs.get('library.music'), ['/new']);
+  assert.deepEqual(prefs.get('library.videos'), ['/Users/test/Movies']);
+  const fresh = freshModule();
+  const store = await fresh.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/new']);
+});
+
+test('subscribe: fires on update with path and newValue', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  const events = [];
+  prefs.subscribe((evt) => events.push(evt));
+  await prefs.update({ library: { scanDesktopAndDownloads: true } });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].path, 'library.scanDesktopAndDownloads');
+  assert.equal(events[0].newValue, true);
+});
+
+test('subscribe: fires once per leaf touched', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  const events = [];
+  prefs.subscribe((evt) => events.push(evt));
+  await prefs.update({
+    library: { music: ['/x'] },
+    sync: { pullDestination: '/y' },
+  });
+  const paths = events.map((e) => e.path).sort();
+  assert.deepEqual(paths, ['library.music', 'sync.pullDestination']);
+});
+
+test('reset: section reset restores defaults for that section only', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({
+    library: { music: ['/x'] },
+    sync: { pullDestination: '/y' },
+  });
+  await prefs.reset('library');
+  assert.deepEqual(prefs.get('library.music'), ['/Users/test/Music']);
+  assert.equal(prefs.get('sync.pullDestination'), '/y');
+});
+
+test('reset: full reset with no argument', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({ sync: { pullDestination: '/y' } });
+  await prefs.reset();
+  assert.equal(prefs.get('sync.pullDestination'), null);
+});
+
+test('load: malformed JSON is preserved as .bad and defaults used', async () => {
+  await fs.writeFile(path.join(tmpDir, 'preferences.json'), '{not json');
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.equal(store.version, 1);
+  const bad = await fs.readFile(path.join(tmpDir, 'preferences.json.bad'), 'utf-8');
+  assert.equal(bad, '{not json');
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npm test`
+Expected: FAIL — `prefs.update is not a function`.
+
+- [ ] **Step 3: Extend the module**
+
+In `src/main/preferences.js`, add these functions above `module.exports`:
+
+```javascript
+function collectLeafPaths(patch, prefix = '') {
+  const out = [];
+  for (const key of Object.keys(patch)) {
+    const v = patch[key];
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...collectLeafPaths(v, p));
+    } else {
+      out.push({ path: p, newValue: v });
+    }
+  }
+  return out;
+}
+
+function deepMerge(target, src) {
+  for (const key of Object.keys(src)) {
+    const sv = src[key];
+    if (sv && typeof sv === 'object' && !Array.isArray(sv)) {
+      if (!target[key] || typeof target[key] !== 'object') target[key] = {};
+      deepMerge(target[key], sv);
+    } else {
+      target[key] = sv;
+    }
+  }
+}
+
+async function update(patch) {
+  if (!state) throw new Error('preferences not loaded');
+  const events = collectLeafPaths(patch);
+  deepMerge(state, patch);
+  scheduleWrite();
+  for (const evt of events) {
+    for (const cb of subscribers) {
+      try { cb(evt); } catch (err) { console.error('preferences subscriber threw', err); }
+    }
+  }
+}
+
+async function reset(section) {
+  if (!state || !storeDir) throw new Error('preferences not loaded');
+  const home = state.__defaultHome || require('node:os').homedir();
+  const defaults = defaultPrefs(home);
+  if (section) {
+    state[section] = defaults[section];
+  } else {
+    state = defaults;
+    state.__defaultHome = home;
+  }
+  await writeNow();
+}
+
+function subscribe(cb) {
+  subscribers.push(cb);
+  return () => { subscribers = subscribers.filter((s) => s !== cb); };
+}
+
+function _resetModule() {
+  state = null;
+  storeDir = null;
+  subscribers = [];
+  if (writeTimer) { clearTimeout(writeTimer); writeTimer = null; }
+}
+```
+
+Update the exports line:
+
+```javascript
+module.exports = { load, get, update, reset, subscribe, SCHEMA_VERSION, _resetModule };
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npm test`
+Expected: all 10 preferences tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/preferences.js tests/preferences.test.js
+git commit -m "feat(preferences): add update, subscribe, reset, malformed-json recovery"
+```
+
+---
+
+## Task 5: Preferences migrations — install-type detection + legacy imports
+
+**Files:**
+- Create: `src/main/preferences-migrations.js`
+- Create: `tests/preferences-migrations.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+`tests/preferences-migrations.test.js`:
+
+```javascript
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+function fresh() {
+  delete require.cache[require.resolve('../src/main/preferences-migrations')];
+  return require('../src/main/preferences-migrations');
+}
+
+let tmpDir;
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prefs-mig-'));
+});
+
+test('detectInstallType: empty userData is new', async () => {
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'new');
+});
+
+test('detectInstallType: pins.json present is upgrade', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pins.json'), '[]');
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'upgrade');
+  assert.deepEqual(r.signals, ['pins.json']);
+});
+
+test('detectInstallType: pull-destination plus playlists is upgrade', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), '{}');
+  await fs.mkdir(path.join(tmpDir, 'playlists'));
+  await fs.writeFile(path.join(tmpDir, 'playlists', 'a.json'), '{}');
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'upgrade');
+  assert.deepEqual(r.signals.sort(), ['playlists/', 'pull-destination.json']);
+});
+
+test('importLegacyFiles: pull-destination becomes sync.pullDestination and file is deleted', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), JSON.stringify({ path: '/my/pulls' }));
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync.pullDestination, '/my/pulls');
+  await assert.rejects(fs.access(path.join(tmpDir, 'pull-destination.json')));
+});
+
+test('importLegacyFiles: no pull-destination yields empty sync patch', async () => {
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync, undefined);
+});
+
+test('importLegacyFiles: corrupt pull-destination is left alone, no patch', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), '{corrupt');
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync, undefined);
+  await fs.access(path.join(tmpDir, 'pull-destination.json'));
+});
+
+test('importLegacyFiles: podcast preferences downloadDirectory becomes podcasts.downloadDirectory', async () => {
+  await fs.mkdir(path.join(tmpDir, 'podcasts'));
+  await fs.writeFile(
+    path.join(tmpDir, 'podcasts', 'preferences.json'),
+    JSON.stringify({ downloadDirectory: '/pods/dl' })
+  );
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.podcasts.downloadDirectory, '/pods/dl');
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `npm test -- tests/preferences-migrations.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+`src/main/preferences-migrations.js`:
+
+```javascript
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const SIGNAL_FILES = [
+  'pins.json',
+  'pull-destination.json',
+  'now-playing.json',
+  'metadata-cache.json',
+];
+const SIGNAL_DIRS = ['playlists'];
+
+async function exists(p) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+async function dirNotEmpty(p) {
+  try {
+    const entries = await fs.readdir(p);
+    return entries.length > 0;
+  } catch { return false; }
+}
+
+async function detectInstallType(userDataDir) {
+  const signals = [];
+  for (const f of SIGNAL_FILES) {
+    if (await exists(path.join(userDataDir, f))) signals.push(f);
+  }
+  for (const d of SIGNAL_DIRS) {
+    if (await dirNotEmpty(path.join(userDataDir, d))) signals.push(d + '/');
+  }
+  if (await exists(path.join(userDataDir, 'podcasts', 'preferences.json'))) {
+    signals.push('podcasts/preferences.json');
+  }
+  return { type: signals.length > 0 ? 'upgrade' : 'new', signals };
+}
+
+async function readJsonSafe(p) {
+  try {
+    const raw = await fs.readFile(p, 'utf-8');
+    return JSON.parse(raw);
+  } catch { return null; }
+}
+
+async function importLegacyFiles(userDataDir) {
+  const patch = {};
+
+  const pullPath = path.join(userDataDir, 'pull-destination.json');
+  const pull = await readJsonSafe(pullPath);
+  if (pull && typeof pull.path === 'string') {
+    patch.sync = { pullDestination: pull.path };
+    try { await fs.unlink(pullPath); } catch {}
+  }
+
+  const podPath = path.join(userDataDir, 'podcasts', 'preferences.json');
+  const pod = await readJsonSafe(podPath);
+  if (pod && typeof pod.downloadDirectory === 'string') {
+    patch.podcasts = { downloadDirectory: pod.downloadDirectory };
+    // Don't delete — podcast-manager may have other keys in it.
+    // It's refactored in a later task to read from the central store.
+  }
+
+  return patch;
+}
+
+module.exports = { detectInstallType, importLegacyFiles };
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `npm test`
+Expected: all 7 migration tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/preferences-migrations.js tests/preferences-migrations.test.js
+git commit -m "feat(preferences): add install-type detection and legacy-file import"
+```
+
+---
+
+## Task 6: Main process — preferences init + IPC + first-run signal
+
+**Files:**
+- Modify: `src/main/main.js`
+
+- [ ] **Step 1: Require the new modules**
+
+Near the top of `src/main/main.js` (after existing requires), add:
+
+```javascript
+const preferences = require('./preferences');
+const { detectInstallType, importLegacyFiles } = require('./preferences-migrations');
+```
+
+- [ ] **Step 2: Wire into boot sequence**
+
+Find the `app.whenReady().then(async () => { ... })` block. Immediately after the existing cache inits (e.g., `metadataCache = new MetadataCache(...)`), add:
+
+```javascript
+const userDataDir = app.getPath('userData');
+const install = await detectInstallType(userDataDir);
+const prefFile = path.join(userDataDir, 'preferences.json');
+const hadPreferencesFile = await fs.access(prefFile).then(() => true).catch(() => false);
+
+await preferences.load(userDataDir, { defaultHome: app.getPath('home') });
+
+let firstRunPayload = null;
+if (!hadPreferencesFile) {
+  const legacyPatch = await importLegacyFiles(userDataDir);
+  if (Object.keys(legacyPatch).length > 0) {
+    await preferences.update(legacyPatch);
+  }
+  await preferences.update({
+    meta: { installedVersion: app.getVersion(), firstRunAt: new Date().toISOString() },
+  });
+  firstRunPayload = { type: install.type, version: app.getVersion() };
+}
+
+preferences.subscribe((evt) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('preferences-changed', evt);
+  }
+});
+```
+
+- [ ] **Step 3: Emit first-run after window is ready**
+
+After `mainWindow` is created (wherever the app currently listens for `ready-to-show` or `did-finish-load`), add:
+
+```javascript
+mainWindow.webContents.once('did-finish-load', () => {
+  if (firstRunPayload) {
+    mainWindow.webContents.send('first-run', firstRunPayload);
+  }
+});
+```
+
+- [ ] **Step 4: Add IPC handlers**
+
+Add these handlers (a good place is near the existing `pick-pull-destination` cluster):
+
+```javascript
+ipcMain.handle('preferences-load', async () => {
+  const current = preferences.get('');
+  if (current !== undefined) return { success: true, preferences: current };
+  const loaded = await preferences.load(app.getPath('userData'), { defaultHome: app.getPath('home') });
+  return { success: true, preferences: loaded };
+});
+
+ipcMain.handle('preferences-update', async (_evt, patch) => {
+  try {
+    if (patch && patch.library) {
+      for (const cat of ['music', 'videos', 'pictures']) {
+        if (Array.isArray(patch.library[cat]) && patch.library[cat].length === 0) {
+          return { success: false, error: `library.${cat} cannot be empty` };
+        }
+      }
+    }
+    await preferences.update(patch);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('preferences-reset', async (_evt, section) => {
+  try {
+    await preferences.reset(section);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('pick-folder', async (_evt, title) => {
+  const { dialog } = require('electron');
+  const r = await dialog.showOpenDialog(mainWindow, {
+    title: title || 'Choose folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (r.canceled || r.filePaths.length === 0) return { success: false, canceled: true };
+  return { success: true, path: r.filePaths[0] };
+});
+
+ipcMain.handle('get-app-version', async () => app.getVersion());
+
+ipcMain.handle('clear-metadata-cache', async () => {
+  try {
+    if (metadataCache && typeof metadataCache.clear === 'function') {
+      await metadataCache.clear();
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('clear-device-cache', async () => {
+  try {
+    if (deviceCache && typeof deviceCache.clear === 'function') {
+      await deviceCache.clear();
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+```
+
+- [ ] **Step 5: Note on `preferences.get('')`**
+
+The current `get('')` returns undefined because `''.split('.')` is `['']`. To return the full store, either:
+- call `get()` with no argument and update the module to return the whole state when called without args, OR
+- in the handler above, access internal state via a new export.
+
+**Update `src/main/preferences.js`**: change the `get` function to:
+
+```javascript
+function get(dotPath) {
+  if (!state) return undefined;
+  if (dotPath === undefined || dotPath === null || dotPath === '') {
+    const copy = { ...state };
+    delete copy.__defaultHome;
+    return copy;
+  }
+  const parts = dotPath.split('.');
+  let cur = state;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+```
+
+Re-run `npm test` to make sure preferences tests still pass.
+
+- [ ] **Step 6: Smoke test**
+
+Run: `npm start`. App launches. Close.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/main.js src/main/preferences.js
+git commit -m "feat(main): wire preferences load/migrate/IPC and first-run signal"
+```
+
+---
+
+## Task 7: Preload — expose preferences + folder picker + first-run
+
+**Files:**
+- Modify: `src/main/preload.js`
+
+- [ ] **Step 1: Add new electronAPI entries**
+
+Inside the `contextBridge.exposeInMainWorld('electronAPI', { ... })` object, append:
+
+```javascript
+preferencesLoad: () => ipcRenderer.invoke('preferences-load'),
+preferencesUpdate: (patch) => ipcRenderer.invoke('preferences-update', patch),
+preferencesReset: (section) => ipcRenderer.invoke('preferences-reset', section),
+onPreferencesChanged: (cb) => {
+  const handler = (_e, evt) => cb(evt);
+  ipcRenderer.on('preferences-changed', handler);
+  return handler;
+},
+offPreferencesChanged: (h) => ipcRenderer.removeListener('preferences-changed', h),
+onFirstRun: (cb) => {
+  const handler = (_e, payload) => cb(payload);
+  ipcRenderer.on('first-run', handler);
+  return handler;
+},
+offFirstRun: (h) => ipcRenderer.removeListener('first-run', h),
+pickFolder: (title) => ipcRenderer.invoke('pick-folder', title),
+getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
+clearDeviceCache: () => ipcRenderer.invoke('clear-device-cache'),
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `npm start`. Open DevTools; verify `window.electronAPI.preferencesLoad` is a function.
+
+Close.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/preload.js
+git commit -m "feat(preload): expose preferences, folder picker, first-run, cache clears"
+```
+
+---
+
+## Task 8: Renderer — cache preferences on boot + subscribe
+
+**Files:**
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Add preferences fields to ZuneExplorer constructor**
+
+In the `constructor()`, after the other field assignments, add:
+
+```javascript
+this.preferences = null;
+this._prefChangeHandler = null;
+this.settingsView = null;
+```
+
+- [ ] **Step 2: Load preferences in init()**
+
+In `async init()`, before the first call that depends on preferences (specifically before `await this.scanFileSystem()`), add:
+
+```javascript
+const prefResult = await window.electronAPI.preferencesLoad();
+if (prefResult && prefResult.success) {
+  this.preferences = prefResult.preferences;
+} else {
+  console.error('Failed to load preferences; using empty defaults');
+  this.preferences = {
+    library: { music: [], videos: [], pictures: [], scanDesktopAndDownloads: false },
+    sync: { pullDestination: null },
+    podcasts: { downloadDirectory: null },
+    meta: {},
+  };
+}
+
+this._prefChangeHandler = window.electronAPI.onPreferencesChanged((evt) => {
+  this._onPreferenceChanged(evt);
+});
+```
+
+- [ ] **Step 3: Add the handler method**
+
+Add to the class, near other lifecycle methods:
+
+```javascript
+_onPreferenceChanged(evt) {
+  const parts = evt.path.split('.');
+  let cur = this.preferences;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (!cur[parts[i]]) cur[parts[i]] = {};
+    cur = cur[parts[i]];
+  }
+  const oldValue = cur[parts[parts.length - 1]];
+  cur[parts[parts.length - 1]] = evt.newValue;
+
+  if (evt.path.startsWith('library.')) {
+    this._handleLibraryPrefChange(evt.path, oldValue, evt.newValue);
+  }
+  if (this.settingsView && this.settingsView.isOpen) {
+    this.settingsView.refresh();
+  }
+}
+
+_handleLibraryPrefChange(_path, _oldValue, _newValue) {
+  // Implemented in Task 10
+}
+```
+
+- [ ] **Step 4: Smoke test**
+
+Run: `npm start`. App launches normally. Close.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assets/js/renderer.js
+git commit -m "feat(renderer): load preferences on init and subscribe to changes"
+```
+
+---
+
+## Task 9: Renderer — read library folders from preferences
+
+**Files:**
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Rewrite `scanMediaFiles`**
+
+Replace the existing `scanMediaFiles` method with:
+
+```javascript
+async scanMediaFiles() {
+  const lib = this.preferences?.library || {};
+  const categoryDirs = {
+    music: lib.music || [],
+    videos: lib.videos || [],
+    pictures: lib.pictures || [],
+  };
+
+  for (const [category, dirs] of Object.entries(categoryDirs)) {
+    for (const dir of dirs) {
+      await this.scanDirectoryRecursive(dir, category);
+    }
+  }
+
+  if (lib.scanDesktopAndDownloads) {
+    const sep = this.platform === 'win32' ? '\\' : '/';
+    const commonDirs = [
+      `${this.homePath}${sep}Desktop`,
+      `${this.homePath}${sep}Downloads`,
+    ];
+    for (const dir of commonDirs) {
+      await this.scanDirectoryForMedia(dir);
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `npm start`.
+- Music/Videos/Pictures from `~/Music`/`~/Movies`/`~/Pictures` still appear.
+- Desktop/Downloads media no longer appears (the new default).
+
+Close.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assets/js/renderer.js
+git commit -m "feat(renderer): read library folders from preferences (fixes #12)"
+```
+
+---
+
+## Task 10: Rescan delta logic
+
+**Files:**
+- Modify: `src/main/preload.js`
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Expose path-utils to the renderer**
+
+In `src/main/preload.js`, at the top alongside other requires:
+
+```javascript
+const pathUtils = require('../shared/path-utils');
+```
+
+Outside the existing `contextBridge.exposeInMainWorld('electronAPI', ...)`, add:
+
+```javascript
+contextBridge.exposeInMainWorld('pathUtils', pathUtils);
+```
+
+- [ ] **Step 2: Implement `_handleLibraryPrefChange`**
+
+Replace the stub in renderer.js:
+
+```javascript
+async _handleLibraryPrefChange(prefPath, oldValue, newValue) {
+  const { computeAddedPaths, computeRemovedPaths, isUnderPrefix, isUnderAnyPrefix } = window.pathUtils;
+
+  const categoryMatch = /^library\.(music|videos|pictures)$/.exec(prefPath);
+  if (categoryMatch) {
+    const category = categoryMatch[1];
+    const added = computeAddedPaths(oldValue || [], newValue || []);
+    const removed = computeRemovedPaths(oldValue || [], newValue || []);
+    const stillCovered = newValue || [];
+
+    if (removed.length) {
+      this.categorizedFiles[category] = this.categorizedFiles[category].filter((f) => {
+        for (const rp of removed) {
+          if (isUnderPrefix(f.path, rp) && !isUnderAnyPrefix(f.path, stillCovered)) return false;
+        }
+        return true;
+      });
+      if (category === 'music') {
+        for (const [tPath] of this.musicLibrary.tracks) {
+          for (const rp of removed) {
+            if (isUnderPrefix(tPath, rp) && !isUnderAnyPrefix(tPath, stillCovered)) {
+              this.musicLibrary.tracks.delete(tPath);
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    for (const dir of added) {
+      await this.scanDirectoryRecursive(dir, category);
+    }
+
+    if (added.length || removed.length) {
+      this.showToast?.(`rescanning ${category}…`);
+      if (category === 'music') await this.scanMusicLibrary();
+      this._refreshCurrentView();
+    }
+    return;
+  }
+
+  if (prefPath === 'library.scanDesktopAndDownloads') {
+    const sep = this.platform === 'win32' ? '\\' : '/';
+    const dirs = [`${this.homePath}${sep}Desktop`, `${this.homePath}${sep}Downloads`];
+    if (newValue) {
+      for (const dir of dirs) await this.scanDirectoryForMedia(dir);
+      this.showToast?.('rescanning desktop & downloads…');
+      await this.scanMusicLibrary();
+    } else {
+      const keep = [
+        ...(this.preferences.library.music || []),
+        ...(this.preferences.library.videos || []),
+        ...(this.preferences.library.pictures || []),
+      ];
+      for (const category of ['music', 'videos', 'pictures']) {
+        this.categorizedFiles[category] = this.categorizedFiles[category].filter((f) => {
+          for (const dir of dirs) {
+            if (isUnderPrefix(f.path, dir) && !isUnderAnyPrefix(f.path, keep)) return false;
+          }
+          return true;
+        });
+      }
+      for (const [tPath] of this.musicLibrary.tracks) {
+        for (const dir of dirs) {
+          if (isUnderPrefix(tPath, dir) && !isUnderAnyPrefix(tPath, keep)) {
+            this.musicLibrary.tracks.delete(tPath);
+            break;
+          }
+        }
+      }
+    }
+    this._refreshCurrentView();
+  }
+}
+
+_refreshCurrentView() {
+  if (!this.currentCategory) return;
+  if (this.currentCategory === 'music') this.renderMusicView?.();
+  else if (this.currentCategory === 'videos' || this.currentCategory === 'pictures') this.renderCategoryContent?.();
+}
+```
+
+- [ ] **Step 3: Smoke test**
+
+Run: `npm start`. Open DevTools. Verify `window.pathUtils.isUnderPrefix('/a/b', '/a')` returns `true`.
+
+Close.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/preload.js src/assets/js/renderer.js
+git commit -m "feat(renderer): compute rescan deltas on library preference changes"
+```
+
+---
+
+## Task 11: BootSplash component
+
+**Files:**
+- Create: `src/assets/js/boot-splash.js`
+- Modify: `src/assets/css/styles.css`
+- Modify: `src/renderer/index.html`
+
+- [ ] **Step 1: Add HTML root**
+
+In `src/renderer/index.html`, near the opening `<body>`:
+
+```html
+<div class="boot-splash" id="boot-splash" style="display:none">
+  <div class="boot-splash-bar" id="boot-splash-bar"></div>
+  <div class="boot-splash-message" id="boot-splash-message"></div>
+</div>
+```
+
+And load the component (match the path-style used by other `<script>` tags):
+
+```html
+<script src="../assets/js/boot-splash.js"></script>
+```
+
+Place it before `renderer.js` so the class is defined when the renderer starts.
+
+- [ ] **Step 2: Add CSS**
+
+Append to `src/assets/css/styles.css`:
+
+```css
+/* Boot / Update splash ------------------------------------------------ */
+.boot-splash {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 300ms ease-out;
+}
+.boot-splash.fading { opacity: 0; pointer-events: none; }
+
+.boot-splash-bar {
+  width: 10vw;
+  min-width: 32px;
+  max-width: 72px;
+  height: 0;
+  max-height: 40vh;
+  background: #EC008C;
+  transition:
+    height 2s cubic-bezier(0.25, 0.1, 0.25, 1),
+    background-color 2s linear;
+}
+.boot-splash-bar.active { height: 40vh; }
+
+.boot-splash-message {
+  margin-top: 32px;
+  font-size: 28px;
+  font-weight: 100;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: lowercase;
+  letter-spacing: 1px;
+}
+```
+
+- [ ] **Step 3: Implement the component**
+
+`src/assets/js/boot-splash.js`:
+
+```javascript
+/* global document */
+class BootSplash {
+  constructor() {
+    this.root = document.getElementById('boot-splash');
+    this.bar = document.getElementById('boot-splash-bar');
+    this.messageEl = document.getElementById('boot-splash-message');
+  }
+
+  async show({ message, task, minDurationMs = 2000, fadeMs = 300 } = {}) {
+    if (!this.root) return;
+    this.messageEl.textContent = message || '';
+    this.root.style.display = 'flex';
+    this.root.classList.remove('fading');
+    void this.bar.offsetHeight;
+
+    const stops = ['#EC008C', '#F58220', '#00ADA7', '#2B3990'];
+    const stopDuration = minDurationMs / (stops.length - 1);
+    this.bar.classList.add('active');
+
+    for (let i = 1; i < stops.length; i++) {
+      await new Promise((r) => setTimeout(r, stopDuration));
+      this.bar.style.backgroundColor = stops[i];
+    }
+
+    if (task && typeof task.then === 'function') {
+      try { await task; } catch (err) { console.warn('BootSplash task failed', err); }
+    }
+
+    this.root.classList.add('fading');
+    await new Promise((r) => setTimeout(r, fadeMs));
+    this.root.style.display = 'none';
+    this.bar.classList.remove('active');
+    this.bar.style.backgroundColor = '';
+  }
+}
+
+window.BootSplash = BootSplash;
+```
+
+- [ ] **Step 4: Smoke test**
+
+Run: `npm start`. In DevTools:
+
+```javascript
+const s = new BootSplash();
+s.show({ message: 'test splash' });
+```
+
+Expected: black overlay with vertical bar growing and cycling through four colors; fades out.
+
+Close.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assets/js/boot-splash.js src/assets/css/styles.css src/renderer/index.html
+git commit -m "feat(renderer): add zune-style boot splash component"
+```
+
+---
+
+## Task 12: BootSplash integration + behavior-change toast
+
+**Files:**
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Listen for first-run after preferences load**
+
+In `async init()`, after preferences are loaded but before `scanFileSystem()`:
+
+```javascript
+const firstRun = await new Promise((resolve) => {
+  const handler = (payload) => {
+    window.electronAPI.offFirstRun(handler);
+    resolve(payload);
+  };
+  window.electronAPI.onFirstRun(handler);
+  setTimeout(() => {
+    window.electronAPI.offFirstRun(handler);
+    resolve(null);
+  }, 500);
+});
+
+if (firstRun) {
+  const splash = new window.BootSplash();
+  const message = firstRun.type === 'new'
+    ? 'welcome to zune explorer'
+    : `updated to v${firstRun.version}`;
+  await splash.show({ message });
+
+  if (firstRun.type === 'upgrade' && !this.preferences.meta?.behaviorChangeToastShown) {
+    setTimeout(() => {
+      this.showToast?.('desktop & downloads are no longer scanned by default. re-enable in settings → library.');
+    }, 500);
+    await window.electronAPI.preferencesUpdate({ meta: { behaviorChangeToastShown: true } });
+  }
+}
+```
+
+- [ ] **Step 2: Manual test — simulated upgrade**
+
+```bash
+cp -R "$HOME/Library/Application Support/zune-explorer" /tmp/zune-backup
+rm "$HOME/Library/Application Support/zune-explorer/preferences.json" 2>/dev/null || true
+npm start
+```
+
+Expected: boot splash with "updated to v1.4" (or current version); after dismiss, toast about Desktop/Downloads appears.
+
+Close. On next launch without the `rm`, no splash, no toast.
+
+Restore if needed: `rm -rf "$HOME/Library/Application Support/zune-explorer" && mv /tmp/zune-backup "$HOME/Library/Application Support/zune-explorer"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assets/js/renderer.js
+git commit -m "feat(renderer): boot splash and behavior-change toast on first run"
+```
+
+---
+
+## Task 13: Settings category — menu item + dispatcher
+
+**Files:**
+- Modify: `src/renderer/index.html`
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Add menu item**
+
+In `src/renderer/index.html`, after the applications menu item:
+
+```html
+<button class="menu-item" data-category="settings">
+    <span class="menu-text">settings</span>
+    <span class="menu-subs">preferences</span>
+</button>
+```
+
+- [ ] **Step 2: Register the category**
+
+In `src/assets/js/renderer.js` constructor:
+
+```javascript
+this.categories = ['music', 'videos', 'pictures', 'podcasts', 'documents', 'applications', 'settings'];
+```
+
+Also extend `this.categorizedFiles`:
+
+```javascript
+this.categorizedFiles = {
+    music: [],
+    videos: [],
+    pictures: [],
+    podcasts: [],
+    documents: [],
+    applications: [],
+    settings: [],
+};
+```
+
+- [ ] **Step 3: Dispatch from `selectCategory`**
+
+Find `selectCategory(index)` and add a settings branch in its if/else chain:
+
+```javascript
+if (this.currentCategory === 'music') {
+    this.musicDrillDown = null;
+    this.renderMusicView();
+} else if (this.currentCategory === 'podcasts') {
+    if (this.podcastPanel) this.podcastPanel.render();
+} else if (this.currentCategory === 'documents') {
+    this.renderRootView();
+} else if (this.currentCategory === 'settings') {
+    if (!this.settingsView) this.settingsView = new window.SettingsView(this);
+    this.settingsView.render();
+} else {
+    this.renderCategoryContent();
+}
+```
+
+- [ ] **Step 4: Add a stub SettingsView**
+
+Create `src/assets/js/settings-view.js`:
+
+```javascript
+/* global document */
+class SettingsView {
+  constructor(explorer) {
+    this.explorer = explorer;
+    this.isOpen = false;
+    this.stack = [];
+  }
+
+  render() {
+    this.isOpen = true;
+    const fileDisplay = document.getElementById('file-display');
+    const contentPanel = document.getElementById('content-panel');
+    contentPanel.classList.add('hero-mode');
+    fileDisplay.innerHTML = '';
+    const view = document.createElement('div');
+    view.className = 'category-view settings-view';
+    const hero = document.createElement('div');
+    hero.className = 'hero-header';
+    hero.textContent = 'settings';
+    view.appendChild(hero);
+    const list = document.createElement('div');
+    list.className = 'settings-list';
+    list.innerHTML = '<div class="settings-row placeholder">coming soon…</div>';
+    view.appendChild(list);
+    fileDisplay.appendChild(view);
+  }
+
+  refresh() { if (this.isOpen) this.render(); }
+}
+
+window.SettingsView = SettingsView;
+```
+
+Load in `src/renderer/index.html` before `renderer.js`:
+
+```html
+<script src="../assets/js/settings-view.js"></script>
+```
+
+- [ ] **Step 5: Smoke test**
+
+Run: `npm start`. The left menu now has a 7th item, "settings". Clicking it shows a hero "settings" + "coming soon…" placeholder.
+
+Close.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/index.html src/assets/js/renderer.js src/assets/js/settings-view.js
+git commit -m "feat(renderer): register settings category with stub SettingsView"
+```
+
+---
+
+## Task 14: SettingsView — drill stack framework + styles
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+- Modify: `src/assets/css/styles.css`
+- Modify: `src/assets/js/renderer.js`
+
+- [ ] **Step 1: Replace settings-view.js**
+
+```javascript
+/* global document */
+class SettingsView {
+  constructor(explorer) {
+    this.explorer = explorer;
+    this.isOpen = false;
+    this.stack = [];
+    this._appVersion = null;
+    (async () => {
+      try { this._appVersion = await window.electronAPI.getAppVersion(); } catch {}
+    })();
+  }
+
+  render() {
+    this.isOpen = true;
+    this.stack = [{ title: 'settings', buildItems: () => this._rootItems() }];
+    this._draw();
+  }
+
+  refresh() { if (this.isOpen) this._draw(); }
+
+  push(pageDescriptor) {
+    this.stack.push(pageDescriptor);
+    this._draw();
+  }
+
+  pop() {
+    if (this.stack.length <= 1) {
+      this.isOpen = false;
+      this.explorer.showMenu?.();
+      return;
+    }
+    this.stack.pop();
+    this._draw();
+  }
+
+  _draw() {
+    const fileDisplay = document.getElementById('file-display');
+    const contentPanel = document.getElementById('content-panel');
+    contentPanel.classList.add('hero-mode');
+    fileDisplay.innerHTML = '';
+
+    const page = this.stack[this.stack.length - 1];
+    const view = document.createElement('div');
+    view.className = 'category-view settings-view';
+
+    const hero = document.createElement('div');
+    hero.className = 'hero-header';
+    hero.textContent = page.title;
+    view.appendChild(hero);
+
+    const content = document.createElement('div');
+    content.className = 'category-content settings-content';
+
+    const list = document.createElement('div');
+    list.className = 'settings-list';
+    for (const item of page.buildItems()) {
+      list.appendChild(this._renderItem(item));
+    }
+    content.appendChild(list);
+    view.appendChild(content);
+    fileDisplay.appendChild(view);
+  }
+
+  _renderItem(item) {
+    const row = document.createElement('div');
+    row.className = 'settings-row';
+    if (item.disabled) row.classList.add('disabled');
+
+    if (item.kind === 'nav' || item.kind === 'action') {
+      row.textContent = item.label;
+      if (!item.disabled) row.addEventListener('click', () => item.onClick());
+    } else if (item.kind === 'toggle') {
+      const label = document.createElement('span');
+      label.className = 'settings-row-label';
+      label.textContent = item.label;
+      row.appendChild(label);
+      const toggle = document.createElement('span');
+      toggle.className = 'settings-toggle' + (item.value ? ' on' : '');
+      row.appendChild(toggle);
+      row.addEventListener('click', () => item.onToggle(!item.value));
+    } else if (item.kind === 'info') {
+      const label = document.createElement('span');
+      label.className = 'settings-row-label';
+      label.textContent = item.label;
+      row.appendChild(label);
+      const val = document.createElement('span');
+      val.className = 'settings-row-value';
+      val.textContent = item.value || '';
+      row.appendChild(val);
+    } else if (item.kind === 'placeholder') {
+      row.textContent = item.label;
+      row.classList.add('placeholder');
+    }
+    return row;
+  }
+
+  _rootItems() {
+    return [{ kind: 'placeholder', label: 'coming soon…' }];
+  }
+}
+
+window.SettingsView = SettingsView;
+```
+
+- [ ] **Step 2: Add styles**
+
+Append to `src/assets/css/styles.css`:
+
+```css
+/* Settings drill-down --------------------------------------------------- */
+.settings-content { position: relative; z-index: 1; margin-top: 130px; }
+.settings-list {
+  display: flex;
+  flex-direction: column;
+  margin-left: 8px;
+  max-width: 720px;
+}
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 12px;
+  font-size: 22px;
+  font-weight: 300;
+  color: #fff;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  user-select: none;
+}
+.settings-row:hover { background: rgba(255, 255, 255, 0.03); }
+.settings-row.disabled { opacity: 0.35; cursor: not-allowed; }
+.settings-row.disabled:hover { background: transparent; }
+.settings-row.placeholder { opacity: 0.4; font-style: italic; cursor: default; }
+.settings-row-value { font-size: 14px; opacity: 0.55; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.settings-row-label { flex: 1; }
+.settings-toggle {
+  width: 40px; height: 20px; border: 1px solid #444; border-radius: 12px;
+  position: relative; transition: background 200ms;
+}
+.settings-toggle::before {
+  content: ''; width: 16px; height: 16px; background: #555; border-radius: 50%;
+  position: absolute; top: 1px; left: 1px; transition: transform 200ms, background 200ms;
+}
+.settings-toggle.on { background: #ff6900; border-color: #ff6900; }
+.settings-toggle.on::before { transform: translateX(20px); background: #fff; }
+```
+
+- [ ] **Step 3: Hook back button to pop**
+
+Find the back button click handler in `renderer.js`. Add, at the top of the handler:
+
+```javascript
+if (this.settingsView && this.settingsView.isOpen) {
+  this.settingsView.pop();
+  return;
+}
+```
+
+- [ ] **Step 4: Smoke test**
+
+Run: `npm start`. Click settings; verify hero and placeholder. Click back button; verify return to menu.
+
+Close.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assets/js/settings-view.js src/assets/css/styles.css src/assets/js/renderer.js
+git commit -m "feat(renderer): SettingsView drill-stack framework and styles"
+```
+
+---
+
+## Task 15: Settings root — 5-item list
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+
+- [ ] **Step 1: Replace `_rootItems`**
+
+```javascript
+_rootItems() {
+  return [
+    { kind: 'nav', label: 'library',  onClick: () => this.push({ title: 'library',  buildItems: () => this._libraryItems()  }) },
+    { kind: 'nav', label: 'sync',     onClick: () => this.push({ title: 'sync',     buildItems: () => this._syncItems()     }) },
+    { kind: 'nav', label: 'podcasts', onClick: () => this.push({ title: 'podcasts', buildItems: () => this._podcastsItems() }) },
+    { kind: 'nav', label: 'data',     onClick: () => this.push({ title: 'data',     buildItems: () => this._dataItems()     }) },
+    { kind: 'nav', label: 'about',    onClick: () => this.push({ title: 'about',    buildItems: () => this._aboutItems()    }) },
+  ];
+}
+
+_libraryItems()  { return [{ kind: 'placeholder', label: 'library — pending' }]; }
+_syncItems()     { return [{ kind: 'placeholder', label: 'sync — pending' }]; }
+_podcastsItems() { return [{ kind: 'placeholder', label: 'podcasts — pending' }]; }
+_dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }
+_aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `npm start`. settings shows 5 items; each navigates into a placeholder page; back returns to root.
+
+Close.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assets/js/settings-view.js
+git commit -m "feat(renderer): SettingsView root list with 5 navigable sections"
+```
+
+---
+
+## Task 16: Library drill + folder lists + folder leaf
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+
+- [ ] **Step 1: Replace `_libraryItems` with full logic**
+
+```javascript
+_libraryItems() {
+  const prefs = this.explorer.preferences;
+  return [
+    {
+      kind: 'nav',
+      label: 'music folders',
+      onClick: () => this.push({ title: 'music folders', buildItems: () => this._folderListItems('music') }),
+    },
+    {
+      kind: 'nav',
+      label: 'video folders',
+      onClick: () => this.push({ title: 'video folders', buildItems: () => this._folderListItems('videos') }),
+    },
+    {
+      kind: 'nav',
+      label: 'picture folders',
+      onClick: () => this.push({ title: 'picture folders', buildItems: () => this._folderListItems('pictures') }),
+    },
+    {
+      kind: 'toggle',
+      label: 'scan desktop and downloads',
+      value: !!prefs?.library?.scanDesktopAndDownloads,
+      onToggle: async (newVal) => {
+        await window.electronAPI.preferencesUpdate({ library: { scanDesktopAndDownloads: newVal } });
+      },
+    },
+  ];
+}
+
+_folderListItems(category) {
+  const list = this.explorer.preferences?.library?.[category] || [];
+  const items = list.map((folderPath) => ({
+    kind: 'nav',
+    label: folderPath,
+    onClick: () => this.push({
+      title: folderPath.split(/[/\\]/).pop() || folderPath,
+      buildItems: () => this._folderLeafItems(category, folderPath),
+    }),
+  }));
+  items.push({
+    kind: 'action',
+    label: '+ add folder',
+    onClick: async () => {
+      const r = await window.electronAPI.pickFolder(`Choose a ${category} folder`);
+      if (r && r.success) {
+        const cur = this.explorer.preferences.library[category] || [];
+        if (cur.includes(r.path)) return;
+        await window.electronAPI.preferencesUpdate({
+          library: { [category]: [...cur, r.path] },
+        });
+      }
+    },
+  });
+  return items;
+}
+
+_folderLeafItems(category, folderPath) {
+  const list = this.explorer.preferences?.library?.[category] || [];
+  const isLast = list.length <= 1;
+  return [
+    { kind: 'info', label: 'path', value: folderPath },
+    {
+      kind: 'action',
+      label: 'reveal in finder',
+      onClick: () => window.electronAPI.showItemInFolder?.(folderPath),
+    },
+    {
+      kind: 'action',
+      label: isLast ? 'remove (last folder — disabled)' : 'remove from library',
+      disabled: isLast,
+      onClick: async () => {
+        if (isLast) return;
+        const confirmed = await this.explorer.showConfirmModal?.(
+          'Remove folder',
+          `Stop scanning ${folderPath}?`
+        );
+        if (!confirmed) return;
+        const next = list.filter((p) => p !== folderPath);
+        await window.electronAPI.preferencesUpdate({ library: { [category]: next } });
+        this.pop();
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `npm start`.
+- settings → library → music folders: shows existing folders + "+ add folder"
+- Add a folder: picker opens, then list shows new folder and toast "rescanning music…"
+- Click a folder: leaf page shows path, reveal, remove
+- With one folder left, remove is disabled
+- Remove a folder: confirm modal, then pops back to folder list; those tracks disappear from the library
+- Back to library, toggle "scan desktop and downloads" on: Desktop/Downloads media appears; toggle off: disappears
+
+Close.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assets/js/settings-view.js
+git commit -m "feat(settings): library drill with folder lists, add/remove, desktop-toggle"
+```
+
+---
+
+## Task 17: Sync leaf
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+
+- [ ] **Step 1: Replace `_syncItems`**
+
+```javascript
+_syncItems() {
+  const dest = this.explorer.preferences?.sync?.pullDestination;
+  return [
+    { kind: 'info', label: 'pull destination', value: dest || '(not set)' },
+    {
+      kind: 'action',
+      label: dest ? 'change destination' : 'choose destination',
+      onClick: async () => {
+        const r = await window.electronAPI.pickFolder('Choose pull destination');
+        if (r && r.success) {
+          await window.electronAPI.preferencesUpdate({ sync: { pullDestination: r.path } });
+        }
+      },
+    },
+    {
+      kind: 'action',
+      label: 'clear destination',
+      disabled: !dest,
+      onClick: async () => {
+        if (!dest) return;
+        await window.electronAPI.preferencesUpdate({ sync: { pullDestination: null } });
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Smoke test + commit**
+
+Run: `npm start`. settings → sync. Verify display, change, clear.
+
+```bash
+git add src/assets/js/settings-view.js
+git commit -m "feat(settings): sync leaf for pull destination"
+```
+
+---
+
+## Task 18: Podcasts leaf
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+
+- [ ] **Step 1: Replace `_podcastsItems`**
+
+```javascript
+_podcastsItems() {
+  const dir = this.explorer.preferences?.podcasts?.downloadDirectory;
+  return [
+    { kind: 'info', label: 'download directory', value: dir || '(not set)' },
+    {
+      kind: 'action',
+      label: dir ? 'change directory' : 'choose directory',
+      onClick: async () => {
+        const r = await window.electronAPI.pickFolder('Choose podcast download directory');
+        if (r && r.success) {
+          await window.electronAPI.preferencesUpdate({ podcasts: { downloadDirectory: r.path } });
+        }
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Smoke test + commit**
+
+Run: `npm start`. settings → podcasts. Verify + change.
+
+```bash
+git add src/assets/js/settings-view.js
+git commit -m "feat(settings): podcasts leaf for download directory"
+```
+
+---
+
+## Task 19: Podcast-manager refactor to use central preferences
+
+**Files:**
+- Modify: `src/main/podcast-manager.js`
+- Modify: `src/main/main.js`
+
+- [ ] **Step 1: Inspect current handling**
+
+Run: `grep -n "downloadDirectory" src/main/podcast-manager.js`
+
+Note every place it reads or writes `downloadDirectory`.
+
+- [ ] **Step 2: Accept an injected getter**
+
+Edit `podcast-manager.js`. In the constructor add an options argument:
+
+```javascript
+constructor(userDataDir, options = {}) {
+  // ...existing init
+  this._getDownloadDirectory = (options && options.getDownloadDirectory) || (() => null);
+  // ...existing init
+}
+```
+
+Every read of `this.preferences.downloadDirectory` (or equivalent) becomes `this._getDownloadDirectory() || <fallback>`.
+
+Every write of `downloadDirectory` into its own preferences file: **remove**. The central store is the writer now.
+
+Keep any OTHER keys the podcast preferences file contains (subscriptions, etc.) untouched. Only stop reading/writing `downloadDirectory` from/to it.
+
+- [ ] **Step 3: Pass the getter in main.js**
+
+In `main.js`, where `podcastManager = new PodcastManager(...)`:
+
+```javascript
+podcastManager = new PodcastManager(app.getPath('userData'), {
+  getDownloadDirectory: () => preferences.get('podcasts.downloadDirectory'),
+});
+```
+
+- [ ] **Step 4: Redirect the old pick-download-directory IPC**
+
+Check the existing handler:
+
+```bash
+grep -n "podcast-pick-download-directory" src/main/main.js
+```
+
+Replace its body with a version that updates preferences instead of podcast-manager state:
+
+```javascript
+ipcMain.handle('podcast-pick-download-directory', async () => {
+  const { dialog } = require('electron');
+  const r = await dialog.showOpenDialog(mainWindow, {
+    title: 'Choose podcast download directory',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (r.canceled || r.filePaths.length === 0) return { success: false };
+  await preferences.update({ podcasts: { downloadDirectory: r.filePaths[0] } });
+  return { success: true, directory: r.filePaths[0] };
+});
+```
+
+- [ ] **Step 5: Smoke test**
+
+Run: `npm start`. Navigate to podcasts. Verify:
+- Downloading an episode works; file lands in the directory configured in central preferences
+- settings → podcasts → change directory → download lands in the new directory
+
+Close.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/podcast-manager.js src/main/main.js
+git commit -m "refactor(podcast): read download directory from central preferences"
+```
+
+---
+
+## Task 20: Data section — clear caches
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+- Possibly modify: `src/main/metadata-cache.js`, `src/main/zune/zune-manager.js` (add `.clear()` if missing)
+
+- [ ] **Step 1: Replace `_dataItems`**
+
+```javascript
+_dataItems() {
+  return [
+    {
+      kind: 'action',
+      label: 'clear metadata cache',
+      onClick: async () => {
+        const ok = await this.explorer.showConfirmModal?.(
+          'Clear metadata cache',
+          'Album art and enriched metadata will be re-downloaded as needed. Continue?'
+        );
+        if (!ok) return;
+        const r = await window.electronAPI.clearMetadataCache();
+        this.explorer.showToast?.(r && r.success ? 'metadata cache cleared' : 'failed to clear metadata cache');
+      },
+    },
+    {
+      kind: 'action',
+      label: 'clear device cache',
+      onClick: async () => {
+        const ok = await this.explorer.showConfirmModal?.(
+          'Clear device cache',
+          'Cached Zune device browse data will be re-fetched on next connect. Continue?'
+        );
+        if (!ok) return;
+        const r = await window.electronAPI.clearDeviceCache();
+        this.explorer.showToast?.(r && r.success ? 'device cache cleared' : 'failed to clear device cache');
+      },
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Ensure `.clear()` methods exist**
+
+Inspect:
+
+```bash
+grep -n "class MetadataCache\|clear" src/main/metadata-cache.js
+grep -rn "class DeviceCache\|clear" src/main/zune/
+```
+
+If `MetadataCache` has no `clear()`, add one that empties the in-memory Map and overwrites the on-disk JSON file with `{}`:
+
+```javascript
+async clear() {
+  this.cache = new Map();
+  try { await fs.writeFile(this.cachePath, '{}'); } catch {}
+}
+```
+
+Mirror for `DeviceCache` (look at its internal state — probably a Map or object, and a JSON file at a known path).
+
+- [ ] **Step 3: Smoke test**
+
+Run: `npm start`. settings → data → clear metadata cache → confirm → toast. Browse music and verify album art re-fetches.
+
+Close.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/assets/js/settings-view.js src/main/metadata-cache.js src/main/zune/
+git commit -m "feat(settings): data section with cache clear actions"
+```
+
+---
+
+## Task 21: About section + openExternal helper
+
+**Files:**
+- Modify: `src/assets/js/settings-view.js`
+- Modify: `src/main/main.js`
+- Modify: `src/main/preload.js`
+
+- [ ] **Step 1: Replace `_aboutItems`**
+
+```javascript
+_aboutItems() {
+  return [
+    { kind: 'info', label: 'version', value: this._appVersion || 'loading…' },
+    {
+      kind: 'action',
+      label: 'github repo',
+      onClick: () => window.electronAPI.openExternal?.('https://github.com/NiceBeard/zune-explorer'),
+    },
+    { kind: 'info', label: 'author',  value: 'NiceBeard' },
+    { kind: 'info', label: 'license', value: 'MIT' },
+  ];
+}
+```
+
+- [ ] **Step 2: Add `openExternal` IPC**
+
+Check: `grep -n "openExternal" src/main/main.js src/main/preload.js`
+
+If not present, add to `main.js`:
+
+```javascript
+ipcMain.handle('open-external', async (_evt, url) => {
+  const { shell } = require('electron');
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return { success: false };
+    await shell.openExternal(url);
+    return { success: true };
+  } catch {
+    return { success: false };
+  }
+});
+```
+
+Add to `preload.js`:
+
+```javascript
+openExternal: (url) => ipcRenderer.invoke('open-external', url),
+```
+
+- [ ] **Step 3: Smoke test + commit**
+
+Run: `npm start`. settings → about. Verify version matches `package.json`; github row opens browser.
+
+```bash
+git add src/assets/js/settings-view.js src/main/main.js src/main/preload.js
+git commit -m "feat(settings): about section with version, repo link, credits"
+```
+
+---
+
+## Task 22: Verify live-refresh end-to-end
+
+**Files:** none — validation-only
+
+- [ ] **Step 1: Manual test**
+
+Run: `npm start`. Navigate to settings → library → music folders.
+
+In a second terminal:
+
+```bash
+python3 -c "
+import json, os
+p = os.path.expanduser('~/Library/Application Support/zune-explorer/preferences.json')
+d = json.load(open(p))
+d['library']['music'].append('/tmp/test-external-edit')
+json.dump(d, open(p, 'w'), indent=2)
+"
+```
+
+This writes the file externally — note that `preferences-changed` is emitted only on updates through the module. External edits bypass the subscriber chain. **Expected behavior: the UI does NOT pick up the external edit.** Add a note to the implementation that preferences should only be edited via IPC; external edits require app restart.
+
+Instead: use the in-app UI to add a folder and watch the list redraw in real time. This is the supported path.
+
+- [ ] **Step 2: Fix if UI redraw via IPC update is broken**
+
+If adding a folder through the UI does not redraw the list:
+- Check DevTools console for errors
+- Check that `preferences.subscribe` fires in main (add a `console.log` temporarily)
+- Check that the renderer's `onPreferencesChanged` handler is invoked
+- Check that `settingsView.refresh()` is called and `_draw()` runs
+
+Only commit if there is a fix.
+
+```bash
+git add -A
+git commit -m "fix(renderer): ensure settings view refreshes on preference changes"
+```
+
+---
+
+## Task 23: Manual acceptance — issue #12 runbook
+
+**Files:** none — validation task
+
+- [ ] **Step 1: Fresh install**
+
+```bash
+mv "$HOME/Library/Application Support/zune-explorer" /tmp/zune-explorer-backup
+```
+
+Launch. Verify:
+- Boot splash: "welcome to zune explorer"
+- No behavior-change toast
+- Music/Videos/Pictures limited to `~/Music`/`~/Movies`/`~/Pictures`
+- settings → library → music folders shows exactly one entry
+- Adding a folder makes its music appear
+
+Restore: `rm -rf "$HOME/Library/Application Support/zune-explorer" && mv /tmp/zune-explorer-backup "$HOME/Library/Application Support/zune-explorer"`
+
+- [ ] **Step 2: Simulated upgrade**
+
+```bash
+rm "$HOME/Library/Application Support/zune-explorer/preferences.json"
+```
+
+Launch. Verify:
+- Boot splash: "updated to v…"
+- Behavior-change toast appears
+- Old `pull-destination.json` absorbed into `preferences.json` (check `settings → sync`)
+- Old file deleted from userData
+- Podcast download directory preserved via central store
+
+- [ ] **Step 3: Issue #12 primary scenarios**
+
+- [ ] Add a custom music folder → tracks appear
+- [ ] Remove the original `~/Music` while custom folder remains → `~/Music` tracks disappear; custom remains
+- [ ] Cannot remove last folder (button disabled)
+- [ ] Toggle scanDesktopAndDownloads on → Desktop/Downloads media appears; off → disappears
+- [ ] Nested case: add `~/Music/Rock` as separate folder, remove `~/Music` → Rock tracks remain
+
+- [ ] **Step 4: Regression sanity**
+
+- [ ] Pins still work
+- [ ] Playlists load and edit
+- [ ] Zune sync still works
+- [ ] Podcast download and playback still work
+- [ ] No new DevTools console errors
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:** Every numbered item in the spec's "In scope (v1)" maps to at least one task (Library/Sync/Podcasts/Data/About → Tasks 16-21; issue #12 → Tasks 9, 10, 16; boot splash → Tasks 11-12; migration → Tasks 5-6; behavior-change toast → Task 12).
+- **Placeholders:** none — every step has concrete code or commands.
+- **Type consistency:** `preferences.update(patch)`, `preferences.get(dotPath)`, `electronAPI.pickFolder(title)`, `onPreferencesChanged(cb)` are identical everywhere they appear.
+- **Testability:** preferences module, migrations, path-utils → `node:test`. UI validated via manual runbook (Task 23).

--- a/docs/superpowers/specs/2026-04-24-settings-page-design.md
+++ b/docs/superpowers/specs/2026-04-24-settings-page-design.md
@@ -12,7 +12,7 @@ Preferences have been squeezed into the app one JSON file at a time (`pull-desti
 
 ### In scope (v1)
 
-1. **Settings as the sixth panorama section** — hero-header-styled top-level category, right of `applications`. Inherits the existing horizontal slide animation between panorama sections; no bespoke animation code.
+1. **Settings as a new top-level category** — hero-header-styled top-level category, right of `applications`. Inherits the existing horizontal slide animation between panorama sections; no bespoke animation code.
 2. **Unified preferences store** — a single schema-versioned `preferences.json` in `userData/`, covering cross-cutting preferences only. User *content* (pins, playlists, now-playing, metadata cache, device cache) stays where it lives.
 3. **Five settings sections** (see §4 for details):
    - Library
@@ -39,7 +39,7 @@ Preferences have been squeezed into the app one JSON file at a time (`pull-desti
 
 ### Panorama placement
 
-Settings is the sixth hero-header section, to the right of `applications`. Hero header uses the existing `.hero-header` pattern: ~340px font, weight 100, lowercase, `rgba(255,255,255,0.55)`, `top: -160px`, `overflow: hidden` on the wrapper. Horizontal slide from/to this section uses the same transition the other five panorama sections use today.
+Settings is a new top-level category at the end of the panorama, to the right of `applications` (current categories: music, videos, pictures, podcasts, documents, applications — settings becomes the seventh). Hero header uses the existing `.hero-header` pattern: ~340px font, weight 100, lowercase, `rgba(255,255,255,0.55)`, `top: -160px`, `overflow: hidden` on the wrapper. Horizontal slide from/to this section uses the same transition the other five panorama sections use today.
 
 ### Internal drill-down
 

--- a/docs/superpowers/specs/2026-04-24-settings-page-design.md
+++ b/docs/superpowers/specs/2026-04-24-settings-page-design.md
@@ -1,0 +1,302 @@
+# Settings Page — Design Spec
+
+**Date:** 2026-04-24
+**Drivers:** GitHub issue #12 (user-selectable library folders); accumulated ad-hoc preferences need a proper home.
+**Status:** Approved design, pre-implementation.
+
+## Motivation
+
+Preferences have been squeezed into the app one JSON file at a time (`pull-destination.json`, podcast download directory, etc.). Issue #12 — "Can't select where music is located" — exposes the bigger problem: there is no surface for users to control how the app behaves. This spec introduces a proper settings experience in keeping with the Zune HD aesthetic.
+
+## Scope
+
+### In scope (v1)
+
+1. **Settings as the sixth panorama section** — hero-header-styled top-level category, right of `applications`. Inherits the existing horizontal slide animation between panorama sections; no bespoke animation code.
+2. **Unified preferences store** — a single schema-versioned `preferences.json` in `userData/`, covering cross-cutting preferences only. User *content* (pins, playlists, now-playing, metadata cache, device cache) stays where it lives.
+3. **Five settings sections** (see §4 for details):
+   - Library
+   - Sync
+   - Podcasts
+   - Data
+   - About
+4. **Issue #12 fix**: per-category library folder lists (Music / Videos / Pictures). Each pre-populated with the OS default, each fully user-controllable. Optional "also scan Desktop and Downloads" toggle, **off by default**.
+5. **Boot/Update splash** — one-time-per-install/upgrade Zune-style vertical-bar animation with welcome/update message. Runs preferences migration behind it.
+6. **Legacy-file migration** — one-shot import of existing preference files into `preferences.json` on first load after upgrade.
+7. **Behavior-change toast** — existing installs see a one-time notice that Desktop/Downloads scanning is no longer default.
+
+### Explicitly out of scope (parked)
+
+- **Skins / accent-color themes** — user-deferred, "some day but not today."
+- Per-folder recursive yes/no (all folders recursive, matches current).
+- Folder exclude-patterns, max-depth, hidden-file toggle.
+- Preferences export/import.
+- Appearance section (panorama snap toggle, etc.).
+- MusicBrainz enrichment toggle.
+- Any deeper fix for issue #12's secondary complaint ("drag-from-documents doesn't sync") — separate bug.
+
+## Visual design
+
+### Panorama placement
+
+Settings is the sixth hero-header section, to the right of `applications`. Hero header uses the existing `.hero-header` pattern: ~340px font, weight 100, lowercase, `rgba(255,255,255,0.55)`, `top: -160px`, `overflow: hidden` on the wrapper. Horizontal slide from/to this section uses the same transition the other five panorama sections use today.
+
+### Internal drill-down
+
+Each settings level is a full page with the same giant clipped hero header plus a left-aligned list of sub-items in white.
+
+**Drill structure:**
+
+```
+settings                           (hero)
+  library                          (hero, drill)
+    music folders                  (hero, drill)
+      /Users/aaron/Music           (hero, leaf — reveal / remove)
+      /Users/aaron/iCloud/Music
+      + add folder
+    video folders                  (same)
+    picture folders                (same)
+    scan desktop and downloads     (toggle — flips in place)
+  sync                             (hero, drill)
+    pull destination               (leaf — shows path, tap to re-pick)
+  podcasts                         (hero, drill)
+    download directory             (leaf — shows path, tap to re-pick)
+  data                             (hero, drill)
+    clear metadata cache           (action)
+    clear device cache             (action)
+  about                            (hero, drill — info only)
+    version, github link, credits
+```
+
+### Styling rules
+
+- **Hero header:** giant clipped, same as other categories, at every drill level.
+- **Sub-items:** left-aligned, white, moderate-size (~20–24px).
+- **No orange section headers inside settings pages.** Orange is reserved for active/selection accents (consistent with the rest of the app).
+- **No indent-based hierarchy.** The hero header and back button ARE the breadcrumb. Full commit to drill-down.
+- **Toggles:** flip in place on tap (no drill needed for leaf booleans).
+- **Folder rows:** tapping a folder drills to a leaf page showing `reveal in finder` and `remove from library`.
+- **Back button:** existing SVG from memory (circle + angular arrow). Same position as hero-mode category views.
+
+## Architecture
+
+### Files added
+
+- `src/main/preferences.js` — single source of truth for preferences. Module-level singleton, loaded at app boot.
+- `src/main/preferences-migrations.js` — legacy-file → `preferences.json` migration.
+- `src/renderer/components/boot-splash.js` (or inline in `renderer.js` — see §7 on split decisions) — the Zune-style boot/update animation.
+- `userData/preferences.json` — persistent preferences (created on first run).
+
+### Files modified
+
+- `src/main/main.js` — boot-time preferences load + migration trigger; IPC handlers for preferences read/write/reset.
+- `src/main/preload.js` — new `electronAPI.preferences*` surface.
+- `src/main/podcast-manager.js` — read `downloadDirectory` from central preferences rather than its own store. Keep its own subscriptions/episodes storage separate (that's user content, not preferences).
+- `src/assets/js/renderer.js` — new `SettingsView`; new scan entry-point reading library folders from preferences rather than hardcoded `~/Music` etc.; wires up boot splash on first-run signal from main.
+- `src/renderer/index.html` — new `.settings-view` panorama section element.
+- `src/assets/css/styles.css` — settings drill-page styles (largely reuses `.hero-header`, `.hero-mode`, back-button, drill-list patterns); boot-splash animation.
+
+### Preferences module API
+
+```js
+// src/main/preferences.js
+const preferences = {
+  async load(),                     // reads preferences.json, runs migration if needed
+  get(dotPath),                     // e.g. get('library.music') → string[]
+  async update(patch),              // deep-merge patch, debounced write (200ms)
+  async reset(section),             // reset a section or whole store to defaults
+  subscribe(cb),                    // fires on update with { path, newValue }
+  _migrate(oldData, targetVersion), // internal schema bumps
+};
+```
+
+### Preferences schema v1
+
+```json
+{
+  "version": 1,
+  "library": {
+    "music":    ["/Users/<user>/Music"],
+    "videos":   ["/Users/<user>/Movies"],
+    "pictures": ["/Users/<user>/Pictures"],
+    "scanDesktopAndDownloads": false
+  },
+  "sync":     { "pullDestination":    null },
+  "podcasts": { "downloadDirectory":  null },
+  "meta": {
+    "installedVersion": "1.5.0",
+    "firstRunAt": "ISO-8601 timestamp"
+  }
+}
+```
+
+Schema rules on load:
+- Unknown top-level or nested keys are dropped (forward-compat: older versions won't explode on newer fields, but also won't preserve them — acceptable for v1).
+- Missing keys get defaults.
+- Malformed JSON is preserved as `preferences.json.bad` and the store falls back to defaults.
+
+### IPC surface
+
+In `preload.js`:
+
+```js
+preferencesLoad:    () => ipcRenderer.invoke('preferences-load'),
+preferencesUpdate:  (patch) => ipcRenderer.invoke('preferences-update', patch),
+preferencesReset:   (section) => ipcRenderer.invoke('preferences-reset', section),
+onPreferencesChanged: (cb) => { /* on 'preferences-changed' */ },
+offPreferencesChanged: (handler) => { /* removeListener */ },
+onFirstRun: (cb) => { /* on 'first-run', payload: { type: 'new' | 'upgrade', oldVersion, newVersion } */ },
+pickFolder: (title) => ipcRenderer.invoke('pick-folder', title),  // generic picker (reused by library, sync, podcasts)
+```
+
+### Data flow — example: user adds a music folder
+
+1. User taps "+ add folder" on `settings → library → music folders`.
+2. Renderer calls `window.electronAPI.pickFolder('Choose a music folder')`.
+3. Main opens native dialog, returns path or `null`.
+4. Renderer calls `preferencesUpdate({ library: { music: [...existing, picked] } })`.
+5. Main debounces, writes `preferences.json`, emits `preferences-changed` with `{ path: 'library.music', newValue: [...] }`.
+6. Renderer listener on `library.music` triggers delta rescan:
+   - New folder → scan just that folder, append to `categorizedFiles.music`
+   - No existing folders dropped → no deletion step
+7. Toast: *"rescanning music…"* during scan; toast dismisses on complete.
+
+### Data flow — example: user removes a music folder
+
+1. User taps folder → leaf page → `remove from library`.
+2. Small confirm modal (existing `showConfirmModal`).
+3. On confirm, renderer computes new list, calls `preferencesUpdate`.
+4. `preferences-changed` fires. Renderer drops tracks from `musicLibrary.tracks` whose `path` starts with the removed folder's prefix. No rescan needed.
+5. Toast: *"removed N tracks from library"*.
+
+## Migration
+
+### Existing-install detection
+
+On main-process boot:
+
+1. Try to read `preferences.json`. If present → skip migration.
+2. If absent → check for any of:
+   - `pins.json`
+   - `playlists/` directory (non-empty)
+   - `pull-destination.json`
+   - `now-playing.json`
+   - podcast-manager preferences file
+3. If any exist → **existing install**. Otherwise → **new install**.
+4. Write `preferences.json` with defaults, then apply legacy-file imports (see below).
+5. Send `first-run` IPC to renderer with `{ type: 'new' | 'upgrade', oldVersion, newVersion }`.
+
+### Legacy-file imports
+
+All imports are best-effort and non-fatal. On success, delete the legacy file; on failure, log and leave it in place.
+
+| Legacy source | Target in `preferences.json` |
+|---|---|
+| `pull-destination.json` → `{ path }` | `sync.pullDestination` |
+| `podcast-manager`'s `downloadDirectory` preference | `podcasts.downloadDirectory` (podcast-manager is updated to read from central store going forward) |
+
+No legacy source for `library.*` — this behavior was hardcoded. All existing installs get OS defaults.
+
+### Desktop/Downloads behavior change
+
+Previously `~/Desktop` and `~/Downloads` were scanned for any media unconditionally. Going forward, gated by `library.scanDesktopAndDownloads` (default `false`).
+
+- **New install:** `false`. No notice.
+- **Existing install:** `false` AND show one-time toast after boot splash: *"Desktop & Downloads are no longer scanned by default. Re-enable in settings → library."* Dismissible. Toast-shown flag is stored in `preferences.meta` so it doesn't repeat.
+
+### Schema version bumps (future)
+
+`preferences.version` is checked on load. If `loaded.version < current`, run ordered `_migrate(prev, next)` functions to transform the old shape, then write back. v1 has no predecessors — this is a hook for future versions.
+
+## Boot/Update splash
+
+A first-run-only animation overlay that plays on new install and on version upgrade.
+
+### Behavior
+
+- Shown **once per install/upgrade**, never on subsequent boots.
+- Main process triggers it by emitting `first-run` IPC after migration completes (or starts, see below).
+- Full-screen black overlay above everything else.
+- Thin vertical bar, ~10% viewport width, centered horizontally, vertically growing from 0 to ~40% viewport height over ~2s.
+- Bar color cycles through four stops (interpolated):
+  1. Pink — `#EC008C`
+  2. Orange — `#F58220`
+  3. Teal — `#00ADA7`
+  4. Deep blue — `#2B3990`
+- Centered message below: `welcome to zune explorer` (new) or `updated to v1.5` (upgrade). Typography: large weight-100 lowercase, consistent with hero headers.
+- Migration runs during the animation. If it finishes faster than 2s, splash holds until min duration. If it takes longer than ~5s, splash extends with a subtle fade on the bar — we should not have hitting this path under normal conditions.
+- On dismiss, splash fades out (~300ms), app becomes interactive, behavior-change toast (if applicable) appears.
+
+### Reusability
+
+Implemented as a small standalone component so it can be reused for future Zune-themed "this is happening" moments (e.g., first device pair). For v1, only the boot/update trigger is wired.
+
+## Rescan semantics
+
+Adding or removing library folders must not re-scan unchanged folders.
+
+- **Add folder:** scan only the new folder; append to existing `categorizedFiles[category]`.
+- **Remove folder:** drop tracks/entries whose `path` is under the removed folder prefix **AND** not also under another currently-configured folder in the same category (guards against nested configurations, e.g., `/Music` and `/Music/rock` both listed). No disk read.
+- **Toggle Desktop/Downloads on:** scan just `~/Desktop` and `~/Downloads` for media.
+- **Toggle off:** drop tracks/entries whose `path` is under `~/Desktop` or `~/Downloads` **AND** not under any currently-configured library folder (guard against overlap if a user added Downloads explicitly).
+
+These are additive/subtractive deltas against the in-memory `categorizedFiles` and `musicLibrary.tracks` structures. Metadata already scanned is retained.
+
+## Testing
+
+### Unit — preferences module (main)
+
+- Load: missing file → defaults written
+- Load: valid file → returned as-is
+- Load: malformed JSON → `.bad` preserved, defaults used
+- Update: deep-merge, debounced write, fires `preferences-changed`
+- Subscribe: callback receives `{ path, newValue }` on update
+- Reset: section-scoped and full-store
+- Migrate: placeholder migration chain runs in order (test with a synthetic v0 → v1)
+
+### Unit — legacy migration
+
+- `pull-destination.json` → `sync.pullDestination`, file deleted on success
+- Podcast directory → `podcasts.downloadDirectory`
+- Migration failure → legacy file preserved, defaults used, no throw
+- Existing-install detection: cover each signal (pins, playlists, pull-dest, now-playing, podcast prefs)
+
+### Component — SettingsView
+
+- Drill stack push/pop; back button pops; reaching root pops to category list
+- Toggle: flips in place, `preferencesUpdate` called with correct path, state persists across remount
+- Folder add: picker → update call → UI row appears
+- Folder remove: confirm modal, update call, row disappears
+- Last-folder-in-category: remove action disabled in UI AND rejected at main-process validation (defense in depth)
+- Change in `preferences.json` from another source triggers re-render via `onPreferencesChanged`
+
+### Component — BootSplash
+
+- Animation resolves after min duration even if migration promise resolves early
+- Migration rejection does NOT block dismissal — splash continues, error logged, defaults applied
+- Does not render on second launch (feature-flagged off after first-run signal handled)
+
+### Manual acceptance (issue #12)
+
+- [ ] On a fresh machine, default-scan matches current behavior *except* Desktop/Downloads (off)
+- [ ] Add a folder containing music → tracks appear after rescan toast
+- [ ] Remove a folder → its tracks disappear, others remain
+- [ ] Toggle Desktop/Downloads on → media there appears
+- [ ] Toggle off → it disappears (unless overlapping with another configured folder)
+- [ ] Upgrade path: existing installs see boot splash, behavior-change toast, and their pull-destination + podcast dir preserved
+
+## Open implementation questions (deferred to plan, not design)
+
+- Whether renderer code for `SettingsView` lives inline in `renderer.js` or gets split into its own file. `renderer.js` is already large — favor split if it cleanly separates, inline if it would create excessive coupling through shared state.
+- Exact debounce window for `preferences-update` writes (200ms proposed; tune during implementation).
+- Whether the boot splash message strings are i18n-ready (v1: no, hardcoded English).
+
+## Acceptance criteria
+
+- Settings panorama section renders with giant clipped hero at every drill level.
+- All 5 sections are reachable and functional.
+- Issue #12 primary ask (choose library folders) works end-to-end on a fresh install and on upgrade.
+- `preferences.json` is the single source of truth for cross-cutting prefs; no other new preference JSON files are added to `userData/`.
+- Boot splash shows exactly once per install/upgrade.
+- Migration is non-fatal: even if every legacy file is corrupt, the app still boots with defaults.
+- No regressions in existing music/video/picture scanning for users who never open Settings.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "electron . --dev",
     "build": "electron-builder",
     "dist": "electron-builder --publish=never",
-    "test": "node --test tests/"
+    "test": "node --test tests/**/*.test.js"
   },
   "keywords": [
     "electron",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "electron .",
     "dev": "electron . --dev",
     "build": "electron-builder",
-    "dist": "electron-builder --publish=never"
+    "dist": "electron-builder --publish=never",
+    "test": "node --test tests/"
   },
   "keywords": [
     "electron",

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -498,6 +498,7 @@ body {
     justify-content: safe center;
     padding: 40px 60px;
     position: relative;
+    min-height: 0;
     overflow-y: auto;
     transform-origin: right center;
     transition: transform var(--transition-duration) var(--transition-easing);
@@ -4112,42 +4113,44 @@ body.platform-linux .now-playing-panel {
   inset: 0;
   background: #000;
   z-index: 9999;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   transition: opacity 300ms ease-out;
 }
 .boot-splash.fading { opacity: 0; pointer-events: none; }
 
 .boot-splash-bar {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
   width: 10vw;
   min-width: 32px;
   max-width: 72px;
-  height: 40vh;
-  background: #EC008C;
-  transform: scaleY(0);
+  height: 60vh;
+  background: linear-gradient(
+    to top,
+    #EC008C 0%,
+    #F58220 35%,
+    #00ADA7 70%,
+    #2B3990 100%
+  );
+  transform: translateX(-50%) scaleY(0);
   transform-origin: bottom center;
-  transition: transform 2s cubic-bezier(0.25, 0.1, 0.25, 1);
+  transition: transform 5s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
 .boot-splash-bar.active {
-  transform: scaleY(1);
-  animation: boot-splash-color-cycle 2s linear forwards;
-}
-@keyframes boot-splash-color-cycle {
-  0%   { background: #EC008C; }
-  33%  { background: #F58220; }
-  66%  { background: #00ADA7; }
-  100% { background: #2B3990; }
+  transform: translateX(-50%) scaleY(1);
 }
 
 .boot-splash-message {
-  margin-top: 32px;
+  position: absolute;
+  top: 22vh;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 28px;
   font-weight: 100;
   color: rgba(255, 255, 255, 0.7);
   text-transform: lowercase;
   letter-spacing: 1px;
+  white-space: nowrap;
 }
 /* Settings drill-down --------------------------------------------------- */
 .settings-content { position: relative; z-index: 1; margin-top: 130px; }

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -500,9 +500,11 @@ body {
     position: relative;
     min-height: 0;
     overflow-y: auto;
+    scrollbar-width: none;
     transform-origin: right center;
     transition: transform var(--transition-duration) var(--transition-easing);
 }
+.menu-container::-webkit-scrollbar { display: none; }
 
 .panoramic-container.show-recent .menu-container {
     transform: scale(0.55);
@@ -2081,6 +2083,8 @@ body.platform-linux .now-playing-panel {
     align-items: center;
     gap: 8px;
     padding: 6px 4px;
+    min-height: 44px;
+    box-sizing: border-box;
     border-bottom: 1px solid #111;
     font-size: 12px;
     color: var(--zune-text-secondary);
@@ -2335,6 +2339,8 @@ body.platform-linux .now-playing-panel {
     align-items: center;
     gap: 8px;
     padding: 8px 4px;
+    min-height: 56px;
+    box-sizing: border-box;
     cursor: pointer;
     border-bottom: 1px solid #111;
     background: rgba(255, 255, 255, 0.02);

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -4103,3 +4103,39 @@ body.platform-linux .now-playing-panel {
   color: rgba(255, 255, 255, 0.5);
   margin-top: 12px;
 }
+
+/* Boot / Update splash ------------------------------------------------ */
+.boot-splash {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 300ms ease-out;
+}
+.boot-splash.fading { opacity: 0; pointer-events: none; }
+
+.boot-splash-bar {
+  width: 10vw;
+  min-width: 32px;
+  max-width: 72px;
+  height: 0;
+  max-height: 40vh;
+  background: #EC008C;
+  transition:
+    height 2s cubic-bezier(0.25, 0.1, 0.25, 1),
+    background-color 2s linear;
+}
+.boot-splash-bar.active { height: 40vh; }
+
+.boot-splash-message {
+  margin-top: 32px;
+  font-size: 28px;
+  font-weight: 100;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: lowercase;
+  letter-spacing: 1px;
+}

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -4139,3 +4139,39 @@ body.platform-linux .now-playing-panel {
   text-transform: lowercase;
   letter-spacing: 1px;
 }
+/* Settings drill-down --------------------------------------------------- */
+.settings-content { position: relative; z-index: 1; margin-top: 130px; }
+.settings-list {
+  display: flex;
+  flex-direction: column;
+  margin-left: 8px;
+  max-width: 720px;
+}
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 12px;
+  font-size: 22px;
+  font-weight: 300;
+  color: #fff;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  user-select: none;
+}
+.settings-row:hover { background: rgba(255, 255, 255, 0.03); }
+.settings-row.disabled { opacity: 0.35; cursor: not-allowed; }
+.settings-row.disabled:hover { background: transparent; }
+.settings-row.placeholder { opacity: 0.4; font-style: italic; cursor: default; }
+.settings-row-value { font-size: 14px; opacity: 0.55; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.settings-row-label { flex: 1; }
+.settings-toggle {
+  width: 40px; height: 20px; border: 1px solid #444; border-radius: 12px;
+  position: relative; transition: background 200ms;
+}
+.settings-toggle::before {
+  content: ''; width: 16px; height: 16px; background: #555; border-radius: 50%;
+  position: absolute; top: 1px; left: 1px; transition: transform 200ms, background 200ms;
+}
+.settings-toggle.on { background: #ff6900; border-color: #ff6900; }
+.settings-toggle.on::before { transform: translateX(20px); background: #fff; }

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -495,7 +495,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    justify-content: center;
+    justify-content: safe center;
     padding: 40px 60px;
     position: relative;
     overflow-y: auto;
@@ -4124,14 +4124,22 @@ body.platform-linux .now-playing-panel {
   width: 10vw;
   min-width: 32px;
   max-width: 72px;
-  height: 0;
-  max-height: 40vh;
+  height: 40vh;
   background: #EC008C;
-  transition:
-    height 2s cubic-bezier(0.25, 0.1, 0.25, 1),
-    background-color 2s linear;
+  transform: scaleY(0);
+  transform-origin: bottom center;
+  transition: transform 2s cubic-bezier(0.25, 0.1, 0.25, 1);
 }
-.boot-splash-bar.active { height: 40vh; }
+.boot-splash-bar.active {
+  transform: scaleY(1);
+  animation: boot-splash-color-cycle 2s linear forwards;
+}
+@keyframes boot-splash-color-cycle {
+  0%   { background: #EC008C; }
+  33%  { background: #F58220; }
+  66%  { background: #00ADA7; }
+  100% { background: #2B3990; }
+}
 
 .boot-splash-message {
   margin-top: 32px;

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -498,6 +498,7 @@ body {
     justify-content: center;
     padding: 40px 60px;
     position: relative;
+    overflow-y: auto;
     transform-origin: right center;
     transition: transform var(--transition-duration) var(--transition-easing);
 }
@@ -2454,6 +2455,7 @@ body.platform-linux .now-playing-panel {
     color: rgba(255, 255, 255, 0.55);
     line-height: 0.75;
     text-transform: lowercase;
+    white-space: nowrap;
     position: absolute;
     top: -160px;
     left: -6px;

--- a/src/assets/js/boot-splash.js
+++ b/src/assets/js/boot-splash.js
@@ -6,7 +6,7 @@ class BootSplash {
     this.messageEl = document.getElementById('boot-splash-message');
   }
 
-  async show({ message, minDurationMs = 2000, fadeMs = 300 } = {}) {
+  async show({ message, minDurationMs = 5000, fadeMs = 300 } = {}) {
     if (!this.root) return;
     this.messageEl.textContent = message || '';
     this.root.style.display = 'flex';

--- a/src/assets/js/boot-splash.js
+++ b/src/assets/js/boot-splash.js
@@ -1,0 +1,37 @@
+/* global document */
+class BootSplash {
+  constructor() {
+    this.root = document.getElementById('boot-splash');
+    this.bar = document.getElementById('boot-splash-bar');
+    this.messageEl = document.getElementById('boot-splash-message');
+  }
+
+  async show({ message, task, minDurationMs = 2000, fadeMs = 300 } = {}) {
+    if (!this.root) return;
+    this.messageEl.textContent = message || '';
+    this.root.style.display = 'flex';
+    this.root.classList.remove('fading');
+    void this.bar.offsetHeight;
+
+    const stops = ['#EC008C', '#F58220', '#00ADA7', '#2B3990'];
+    const stopDuration = minDurationMs / (stops.length - 1);
+    this.bar.classList.add('active');
+
+    for (let i = 1; i < stops.length; i++) {
+      await new Promise((r) => setTimeout(r, stopDuration));
+      this.bar.style.backgroundColor = stops[i];
+    }
+
+    if (task && typeof task.then === 'function') {
+      try { await task; } catch (err) { console.warn('BootSplash task failed', err); }
+    }
+
+    this.root.classList.add('fading');
+    await new Promise((r) => setTimeout(r, fadeMs));
+    this.root.style.display = 'none';
+    this.bar.classList.remove('active');
+    this.bar.style.backgroundColor = '';
+  }
+}
+
+window.BootSplash = BootSplash;

--- a/src/assets/js/boot-splash.js
+++ b/src/assets/js/boot-splash.js
@@ -13,14 +13,9 @@ class BootSplash {
     this.root.classList.remove('fading');
     void this.bar.offsetHeight;
 
-    const stops = ['#EC008C', '#F58220', '#00ADA7', '#2B3990'];
-    const stopDuration = minDurationMs / (stops.length - 1);
     this.bar.classList.add('active');
 
-    for (let i = 1; i < stops.length; i++) {
-      await new Promise((r) => setTimeout(r, stopDuration));
-      this.bar.style.backgroundColor = stops[i];
-    }
+    await new Promise((r) => setTimeout(r, minDurationMs));
 
     if (task && typeof task.then === 'function') {
       try { await task; } catch (err) { console.warn('BootSplash task failed', err); }
@@ -30,7 +25,6 @@ class BootSplash {
     await new Promise((r) => setTimeout(r, fadeMs));
     this.root.style.display = 'none';
     this.bar.classList.remove('active');
-    this.bar.style.backgroundColor = '';
   }
 }
 

--- a/src/assets/js/boot-splash.js
+++ b/src/assets/js/boot-splash.js
@@ -6,7 +6,7 @@ class BootSplash {
     this.messageEl = document.getElementById('boot-splash-message');
   }
 
-  async show({ message, task, minDurationMs = 2000, fadeMs = 300 } = {}) {
+  async show({ message, minDurationMs = 2000, fadeMs = 300 } = {}) {
     if (!this.root) return;
     this.messageEl.textContent = message || '';
     this.root.style.display = 'flex';
@@ -16,10 +16,6 @@ class BootSplash {
     this.bar.classList.add('active');
 
     await new Promise((r) => setTimeout(r, minDurationMs));
-
-    if (task && typeof task.then === 'function') {
-      try { await task; } catch (err) { console.warn('BootSplash task failed', err); }
-    }
 
     this.root.classList.add('fading');
     await new Promise((r) => setTimeout(r, fadeMs));

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2080,6 +2080,9 @@ class ZuneExplorer {
         this.nowPlayingOpen = false;
         this.zunePanel = null;
         this.podcastPanel = null;
+        this.preferences = null;
+        this._prefChangeHandler = null;
+        this.settingsView = null;
 
         // Music library state
         this.musicLibrary = {
@@ -2116,6 +2119,24 @@ class ZuneExplorer {
         }
         this.homePath = await window.electronAPI.getHomeDirectory();
         this.userDataPath = await window.electronAPI.getUserDataPath();
+
+        const prefResult = await window.electronAPI.preferencesLoad();
+        if (prefResult && prefResult.success) {
+            this.preferences = prefResult.preferences;
+        } else {
+            console.error('Failed to load preferences; using empty defaults');
+            this.preferences = {
+                library: { music: [], videos: [], pictures: [], scanDesktopAndDownloads: false },
+                sync: { pullDestination: null },
+                podcasts: { downloadDirectory: null },
+                meta: {},
+            };
+        }
+
+        this._prefChangeHandler = window.electronAPI.onPreferencesChanged((evt) => {
+            this._onPreferenceChanged(evt);
+        });
+
         this.podcastPanel = new PodcastPanel(this);
         const sf = await window.electronAPI.getSpecialFolders();
         if (this.platform === 'win32') {
@@ -2871,6 +2892,28 @@ class ZuneExplorer {
 
     focusMenu() {
         // Keep keyboard navigation tracking but no visual focus
+    }
+
+    _onPreferenceChanged(evt) {
+        const parts = evt.path.split('.');
+        let cur = this.preferences;
+        for (let i = 0; i < parts.length - 1; i++) {
+            if (!cur[parts[i]]) cur[parts[i]] = {};
+            cur = cur[parts[i]];
+        }
+        const oldValue = cur[parts[parts.length - 1]];
+        cur[parts[parts.length - 1]] = evt.newValue;
+
+        if (evt.path.startsWith('library.')) {
+            this._handleLibraryPrefChange(evt.path, oldValue, evt.newValue);
+        }
+        if (this.settingsView && this.settingsView.isOpen) {
+            this.settingsView.refresh();
+        }
+    }
+
+    _handleLibraryPrefChange(_path, _oldValue, _newValue) {
+        // Implemented in Task 10
     }
 
     async scanFileSystem() {

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2912,8 +2912,85 @@ class ZuneExplorer {
         }
     }
 
-    _handleLibraryPrefChange(_path, _oldValue, _newValue) {
-        // Implemented in Task 10
+    async _handleLibraryPrefChange(prefPath, oldValue, newValue) {
+        const { computeAddedPaths, computeRemovedPaths, isUnderPrefix, isUnderAnyPrefix } = window.pathUtils;
+
+        const categoryMatch = /^library\.(music|videos|pictures)$/.exec(prefPath);
+        if (categoryMatch) {
+            const category = categoryMatch[1];
+            const added = computeAddedPaths(oldValue || [], newValue || []);
+            const removed = computeRemovedPaths(oldValue || [], newValue || []);
+            const stillCovered = newValue || [];
+
+            if (removed.length) {
+                this.categorizedFiles[category] = this.categorizedFiles[category].filter((f) => {
+                    for (const rp of removed) {
+                        if (isUnderPrefix(f.path, rp) && !isUnderAnyPrefix(f.path, stillCovered)) return false;
+                    }
+                    return true;
+                });
+                if (category === 'music') {
+                    for (const [tPath] of this.musicLibrary.tracks) {
+                        for (const rp of removed) {
+                            if (isUnderPrefix(tPath, rp) && !isUnderAnyPrefix(tPath, stillCovered)) {
+                                this.musicLibrary.tracks.delete(tPath);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (const dir of added) {
+                await this.scanDirectoryRecursive(dir, category);
+            }
+
+            if (added.length || removed.length) {
+                this.showToast?.(`rescanning ${category}…`);
+                if (category === 'music') await this.scanMusicLibrary();
+                this._refreshCurrentView();
+            }
+            return;
+        }
+
+        if (prefPath === 'library.scanDesktopAndDownloads') {
+            const sep = this.platform === 'win32' ? '\\' : '/';
+            const dirs = [`${this.homePath}${sep}Desktop`, `${this.homePath}${sep}Downloads`];
+            if (newValue) {
+                for (const dir of dirs) await this.scanDirectoryForMedia(dir);
+                this.showToast?.('rescanning desktop & downloads…');
+                await this.scanMusicLibrary();
+            } else {
+                const keep = [
+                    ...(this.preferences.library.music || []),
+                    ...(this.preferences.library.videos || []),
+                    ...(this.preferences.library.pictures || []),
+                ];
+                for (const category of ['music', 'videos', 'pictures']) {
+                    this.categorizedFiles[category] = this.categorizedFiles[category].filter((f) => {
+                        for (const dir of dirs) {
+                            if (isUnderPrefix(f.path, dir) && !isUnderAnyPrefix(f.path, keep)) return false;
+                        }
+                        return true;
+                    });
+                }
+                for (const [tPath] of this.musicLibrary.tracks) {
+                    for (const dir of dirs) {
+                        if (isUnderPrefix(tPath, dir) && !isUnderAnyPrefix(tPath, keep)) {
+                            this.musicLibrary.tracks.delete(tPath);
+                            break;
+                        }
+                    }
+                }
+            }
+            this._refreshCurrentView();
+        }
+    }
+
+    _refreshCurrentView() {
+        if (!this.currentCategory) return;
+        if (this.currentCategory === 'music') this.renderMusicView?.();
+        else if (this.currentCategory === 'videos' || this.currentCategory === 'pictures') this.renderCategoryContent?.();
     }
 
     async scanFileSystem() {

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2931,11 +2931,11 @@ class ZuneExplorer {
     }
 
     async scanMediaFiles() {
-        const sep = this.platform === 'win32' ? '\\' : '/';
+        const lib = this.preferences?.library || {};
         const categoryDirs = {
-            music: [`${this.homePath}${sep}Music`],
-            videos: [this.platform === 'darwin' ? `${this.homePath}${sep}Movies` : `${this.homePath}${sep}Videos`],
-            pictures: [`${this.homePath}${sep}Pictures`],
+            music: lib.music || [],
+            videos: lib.videos || [],
+            pictures: lib.pictures || [],
         };
 
         for (const [category, dirs] of Object.entries(categoryDirs)) {
@@ -2944,12 +2944,15 @@ class ZuneExplorer {
             }
         }
 
-        const commonDirs = [
-            `${this.homePath}${sep}Desktop`,
-            `${this.homePath}${sep}Downloads`,
-        ];
-        for (const dir of commonDirs) {
-            await this.scanDirectoryForMedia(dir);
+        if (lib.scanDesktopAndDownloads) {
+            const sep = this.platform === 'win32' ? '\\' : '/';
+            const commonDirs = [
+                `${this.homePath}${sep}Desktop`,
+                `${this.homePath}${sep}Downloads`,
+            ];
+            for (const dir of commonDirs) {
+                await this.scanDirectoryForMedia(dir);
+            }
         }
     }
 

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2137,6 +2137,33 @@ class ZuneExplorer {
             this._onPreferenceChanged(evt);
         });
 
+        const firstRun = await new Promise((resolve) => {
+            const handler = (payload) => {
+                window.electronAPI.offFirstRun(handler);
+                resolve(payload);
+            };
+            window.electronAPI.onFirstRun(handler);
+            setTimeout(() => {
+                window.electronAPI.offFirstRun(handler);
+                resolve(null);
+            }, 500);
+        });
+
+        if (firstRun) {
+            const splash = new window.BootSplash();
+            const message = firstRun.type === 'new'
+                ? 'welcome to zune explorer'
+                : `updated to v${firstRun.version}`;
+            await splash.show({ message });
+
+            if (firstRun.type === 'upgrade' && !this.preferences.meta?.behaviorChangeToastShown) {
+                setTimeout(() => {
+                    this.showToast?.('desktop & downloads are no longer scanned by default. re-enable in settings → library.');
+                }, 500);
+                await window.electronAPI.preferencesUpdate({ meta: { behaviorChangeToastShown: true } });
+            }
+        }
+
         this.podcastPanel = new PodcastPanel(this);
         const sf = await window.electronAPI.getSpecialFolders();
         if (this.platform === 'win32') {

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2138,17 +2138,7 @@ class ZuneExplorer {
             this._onPreferenceChanged(evt);
         });
 
-        const firstRun = await new Promise((resolve) => {
-            const handler = (payload) => {
-                window.electronAPI.offFirstRun(handler);
-                resolve(payload);
-            };
-            window.electronAPI.onFirstRun(handler);
-            setTimeout(() => {
-                window.electronAPI.offFirstRun(handler);
-                resolve(null);
-            }, 500);
-        });
+        const firstRun = await window.electronAPI.consumeFirstRun();
 
         if (firstRun) {
             const splash = new window.BootSplash();

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2047,14 +2047,15 @@ class ZuneExplorer {
         this.currentCategory = null;
         this.currentMenuIndex = 0;
         this.currentViewMode = 'grid'; // grid, list
-        this.categories = ['music', 'videos', 'pictures', 'podcasts', 'documents', 'applications'];
+        this.categories = ['music', 'videos', 'pictures', 'podcasts', 'documents', 'applications', 'settings'];
         this.categorizedFiles = {
             music: [],
             videos: [],
             pictures: [],
             podcasts: [],
             documents: [],
-            applications: []
+            applications: [],
+            settings: []
         };
         this.recentFiles = [];
         this.pinnedItems = [];
@@ -2509,6 +2510,9 @@ class ZuneExplorer {
             if (this.podcastPanel) this.podcastPanel.render();
         } else if (this.currentCategory === 'documents') {
             this.renderRootView();
+        } else if (this.currentCategory === 'settings') {
+            if (!this.settingsView) this.settingsView = new window.SettingsView(this);
+            this.settingsView.render();
         } else {
             this.renderCategoryContent();
         }

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2913,6 +2913,10 @@ class ZuneExplorer {
     }
 
     navigateBack() {
+        if (this.settingsView && this.settingsView.isOpen) {
+            this.settingsView.pop();
+            return;
+        }
         if (this.navStack.length > 0) {
             const state = this.navStack.pop();
             this.restoreNavState(state);

--- a/src/assets/js/renderer.js
+++ b/src/assets/js/renderer.js
@@ -2236,18 +2236,8 @@ class ZuneExplorer {
 
         // Context menu actions are now handled dynamically by showDynamicContextMenu()
 
-        // Mouse wheel for vertical scrolling in menu
-        const menuContainer = document.querySelector('.menu-container');
-        menuContainer.addEventListener('wheel', (e) => {
-            e.preventDefault();
-            if (this.currentView === 'menu') {
-                if (e.deltaY > 0) {
-                    this.navigateMenuDown();
-                } else {
-                    this.navigateMenuUp();
-                }
-            }
-        });
+        // Mouse wheel scrolls the menu container natively when items overflow.
+        // (Keyboard arrows still drive currentMenuIndex for keyboard nav.)
 
         // Horizontal swipe/wheel to switch carousel panels
         document.getElementById('panoramic-container').addEventListener('wheel', (e) => {

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -216,7 +216,22 @@ class SettingsView {
       },
     ];
   }
-  _podcastsItems() { return [{ kind: 'placeholder', label: 'podcasts — pending' }]; }
+  _podcastsItems() {
+    const dir = this.explorer.preferences?.podcasts?.downloadDirectory;
+    return [
+      { kind: 'info', label: 'download directory', value: dir || '(not set)' },
+      {
+        kind: 'action',
+        label: dir ? 'change directory' : 'choose directory',
+        onClick: async () => {
+          const r = await window.electronAPI.pickFolder('Choose podcast download directory');
+          if (r && r.success) {
+            await window.electronAPI.preferencesUpdate({ podcasts: { downloadDirectory: r.path } });
+          }
+        },
+      },
+    ];
+  }
   _dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }
   _aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }
 }

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -232,7 +232,36 @@ class SettingsView {
       },
     ];
   }
-  _dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }
+  _dataItems() {
+    return [
+      {
+        kind: 'action',
+        label: 'clear metadata cache',
+        onClick: async () => {
+          const ok = await this.explorer.showConfirmModal?.(
+            'Clear metadata cache',
+            'Album art and enriched metadata will be re-downloaded as needed. Continue?'
+          );
+          if (!ok) return;
+          const r = await window.electronAPI.clearMetadataCache();
+          this.explorer.showToast?.(r && r.success ? 'metadata cache cleared' : 'failed to clear metadata cache');
+        },
+      },
+      {
+        kind: 'action',
+        label: 'clear device cache',
+        onClick: async () => {
+          const ok = await this.explorer.showConfirmModal?.(
+            'Clear device cache',
+            'Cached Zune device browse data will be re-fetched on next connect. Continue?'
+          );
+          if (!ok) return;
+          const r = await window.electronAPI.clearDeviceCache();
+          this.explorer.showToast?.(r && r.success ? 'device cache cleared' : 'failed to clear device cache');
+        },
+      },
+    ];
+  }
   _aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }
 }
 

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -4,28 +4,99 @@ class SettingsView {
     this.explorer = explorer;
     this.isOpen = false;
     this.stack = [];
+    this._appVersion = null;
+    (async () => {
+      try { this._appVersion = await window.electronAPI.getAppVersion(); } catch {}
+    })();
   }
 
   render() {
     this.isOpen = true;
+    this.stack = [{ title: 'settings', buildItems: () => this._rootItems() }];
+    this._draw();
+  }
+
+  refresh() { if (this.isOpen) this._draw(); }
+
+  push(pageDescriptor) {
+    this.stack.push(pageDescriptor);
+    this._draw();
+  }
+
+  pop() {
+    if (this.stack.length <= 1) {
+      this.isOpen = false;
+      this.explorer.showMenu?.();
+      return;
+    }
+    this.stack.pop();
+    this._draw();
+  }
+
+  _draw() {
     const fileDisplay = document.getElementById('file-display');
     const contentPanel = document.getElementById('content-panel');
     contentPanel.classList.add('hero-mode');
     fileDisplay.innerHTML = '';
+
+    const page = this.stack[this.stack.length - 1];
     const view = document.createElement('div');
     view.className = 'category-view settings-view';
+
     const hero = document.createElement('div');
     hero.className = 'hero-header';
-    hero.textContent = 'settings';
+    hero.textContent = page.title;
     view.appendChild(hero);
+
+    const content = document.createElement('div');
+    content.className = 'category-content settings-content';
+
     const list = document.createElement('div');
     list.className = 'settings-list';
-    list.innerHTML = '<div class="settings-row placeholder">coming soon…</div>';
-    view.appendChild(list);
+    for (const item of page.buildItems()) {
+      list.appendChild(this._renderItem(item));
+    }
+    content.appendChild(list);
+    view.appendChild(content);
     fileDisplay.appendChild(view);
   }
 
-  refresh() { if (this.isOpen) this.render(); }
+  _renderItem(item) {
+    const row = document.createElement('div');
+    row.className = 'settings-row';
+    if (item.disabled) row.classList.add('disabled');
+
+    if (item.kind === 'nav' || item.kind === 'action') {
+      row.textContent = item.label;
+      if (!item.disabled) row.addEventListener('click', () => item.onClick());
+    } else if (item.kind === 'toggle') {
+      const label = document.createElement('span');
+      label.className = 'settings-row-label';
+      label.textContent = item.label;
+      row.appendChild(label);
+      const toggle = document.createElement('span');
+      toggle.className = 'settings-toggle' + (item.value ? ' on' : '');
+      row.appendChild(toggle);
+      row.addEventListener('click', () => item.onToggle(!item.value));
+    } else if (item.kind === 'info') {
+      const label = document.createElement('span');
+      label.className = 'settings-row-label';
+      label.textContent = item.label;
+      row.appendChild(label);
+      const val = document.createElement('span');
+      val.className = 'settings-row-value';
+      val.textContent = item.value || '';
+      row.appendChild(val);
+    } else if (item.kind === 'placeholder') {
+      row.textContent = item.label;
+      row.classList.add('placeholder');
+    }
+    return row;
+  }
+
+  _rootItems() {
+    return [{ kind: 'placeholder', label: 'coming soon…' }];
+  }
 }
 
 window.SettingsView = SettingsView;

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -95,8 +95,20 @@ class SettingsView {
   }
 
   _rootItems() {
-    return [{ kind: 'placeholder', label: 'coming soon…' }];
+    return [
+      { kind: 'nav', label: 'library',  onClick: () => this.push({ title: 'library',  buildItems: () => this._libraryItems()  }) },
+      { kind: 'nav', label: 'sync',     onClick: () => this.push({ title: 'sync',     buildItems: () => this._syncItems()     }) },
+      { kind: 'nav', label: 'podcasts', onClick: () => this.push({ title: 'podcasts', buildItems: () => this._podcastsItems() }) },
+      { kind: 'nav', label: 'data',     onClick: () => this.push({ title: 'data',     buildItems: () => this._dataItems()     }) },
+      { kind: 'nav', label: 'about',    onClick: () => this.push({ title: 'about',    buildItems: () => this._aboutItems()    }) },
+    ];
   }
+
+  _libraryItems()  { return [{ kind: 'placeholder', label: 'library — pending' }]; }
+  _syncItems()     { return [{ kind: 'placeholder', label: 'sync — pending' }]; }
+  _podcastsItems() { return [{ kind: 'placeholder', label: 'podcasts — pending' }]; }
+  _dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }
+  _aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }
 }
 
 window.SettingsView = SettingsView;

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -191,7 +191,31 @@ class SettingsView {
     ];
   }
 
-  _syncItems()     { return [{ kind: 'placeholder', label: 'sync — pending' }]; }
+  _syncItems() {
+    const dest = this.explorer.preferences?.sync?.pullDestination;
+    return [
+      { kind: 'info', label: 'pull destination', value: dest || '(not set)' },
+      {
+        kind: 'action',
+        label: dest ? 'change destination' : 'choose destination',
+        onClick: async () => {
+          const r = await window.electronAPI.pickFolder('Choose pull destination');
+          if (r && r.success) {
+            await window.electronAPI.preferencesUpdate({ sync: { pullDestination: r.path } });
+          }
+        },
+      },
+      {
+        kind: 'action',
+        label: 'clear destination',
+        disabled: !dest,
+        onClick: async () => {
+          if (!dest) return;
+          await window.electronAPI.preferencesUpdate({ sync: { pullDestination: null } });
+        },
+      },
+    ];
+  }
   _podcastsItems() { return [{ kind: 'placeholder', label: 'podcasts — pending' }]; }
   _dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }
   _aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -1,0 +1,31 @@
+/* global document */
+class SettingsView {
+  constructor(explorer) {
+    this.explorer = explorer;
+    this.isOpen = false;
+    this.stack = [];
+  }
+
+  render() {
+    this.isOpen = true;
+    const fileDisplay = document.getElementById('file-display');
+    const contentPanel = document.getElementById('content-panel');
+    contentPanel.classList.add('hero-mode');
+    fileDisplay.innerHTML = '';
+    const view = document.createElement('div');
+    view.className = 'category-view settings-view';
+    const hero = document.createElement('div');
+    hero.className = 'hero-header';
+    hero.textContent = 'settings';
+    view.appendChild(hero);
+    const list = document.createElement('div');
+    list.className = 'settings-list';
+    list.innerHTML = '<div class="settings-row placeholder">coming soon…</div>';
+    view.appendChild(list);
+    fileDisplay.appendChild(view);
+  }
+
+  refresh() { if (this.isOpen) this.render(); }
+}
+
+window.SettingsView = SettingsView;

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -262,7 +262,18 @@ class SettingsView {
       },
     ];
   }
-  _aboutItems()    { return [{ kind: 'placeholder', label: 'about — pending' }]; }
+  _aboutItems() {
+    return [
+      { kind: 'info', label: 'version', value: this._appVersion || 'loading…' },
+      {
+        kind: 'action',
+        label: 'github repo',
+        onClick: () => window.electronAPI.openExternal?.('https://github.com/NiceBeard/zune-explorer'),
+      },
+      { kind: 'info', label: 'author',  value: 'NiceBeard' },
+      { kind: 'info', label: 'license', value: 'MIT' },
+    ];
+  }
 }
 
 window.SettingsView = SettingsView;

--- a/src/assets/js/settings-view.js
+++ b/src/assets/js/settings-view.js
@@ -104,7 +104,93 @@ class SettingsView {
     ];
   }
 
-  _libraryItems()  { return [{ kind: 'placeholder', label: 'library — pending' }]; }
+  _libraryItems() {
+    const prefs = this.explorer.preferences;
+    return [
+      {
+        kind: 'nav',
+        label: 'music folders',
+        onClick: () => this.push({ title: 'music folders', buildItems: () => this._folderListItems('music') }),
+      },
+      {
+        kind: 'nav',
+        label: 'video folders',
+        onClick: () => this.push({ title: 'video folders', buildItems: () => this._folderListItems('videos') }),
+      },
+      {
+        kind: 'nav',
+        label: 'picture folders',
+        onClick: () => this.push({ title: 'picture folders', buildItems: () => this._folderListItems('pictures') }),
+      },
+      {
+        kind: 'toggle',
+        label: 'scan desktop and downloads',
+        value: !!prefs?.library?.scanDesktopAndDownloads,
+        onToggle: async (newVal) => {
+          await window.electronAPI.preferencesUpdate({ library: { scanDesktopAndDownloads: newVal } });
+        },
+      },
+    ];
+  }
+
+  _folderListItems(category) {
+    const list = this.explorer.preferences?.library?.[category] || [];
+    const items = list.map((folderPath) => ({
+      kind: 'nav',
+      label: folderPath,
+      onClick: () => this.push({
+        title: folderPath.split(/[/\\]/).pop() || folderPath,
+        buildItems: () => this._folderLeafItems(category, folderPath),
+      }),
+    }));
+    items.push({
+      kind: 'action',
+      label: '+ add folder',
+      onClick: async () => {
+        const r = await window.electronAPI.pickFolder(`Choose a ${category} folder`);
+        if (r && r.success) {
+          const cur = this.explorer.preferences.library[category] || [];
+          if (cur.includes(r.path)) return;
+          await window.electronAPI.preferencesUpdate({
+            library: { [category]: [...cur, r.path] },
+          });
+        }
+      },
+    });
+    return items;
+  }
+
+  _folderLeafItems(category, folderPath) {
+    const list = this.explorer.preferences?.library?.[category] || [];
+    const isLast = list.length <= 1;
+    return [
+      { kind: 'info', label: 'path', value: folderPath },
+      {
+        kind: 'action',
+        label: 'reveal in finder',
+        onClick: () => window.electronAPI.showItemInFolder?.(folderPath),
+      },
+      {
+        kind: 'action',
+        label: isLast ? 'remove (last folder — disabled)' : 'remove from library',
+        disabled: isLast,
+        onClick: async () => {
+          if (isLast) return;
+          const confirmed = await this.explorer.showConfirmModal?.(
+            'Remove folder',
+            `Stop scanning ${folderPath}?`
+          );
+          if (!confirmed) return;
+          const next = list.filter((p) => p !== folderPath);
+          await window.electronAPI.preferencesUpdate({
+            library: { [category]: next },
+          });
+          this.pop();
+        },
+      },
+    ];
+  }
+
   _syncItems()     { return [{ kind: 'placeholder', label: 'sync — pending' }]; }
   _podcastsItems() { return [{ kind: 'placeholder', label: 'podcasts — pending' }]; }
   _dataItems()     { return [{ kind: 'placeholder', label: 'data — pending' }]; }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -26,6 +26,7 @@ let podcastManager = null;
 const isDev = process.env.NODE_ENV === 'development' || process.argv.includes('--dev');
 
 let mainWindow;
+let pendingFirstRun = null;
 
 // Path validation: restrict file operations to allowed directories
 function isAllowedPath(filePath) {
@@ -109,7 +110,6 @@ app.whenReady().then(async () => {
 
   await preferences.load(userDataDir, { defaultHome: app.getPath('home') });
 
-  let firstRunPayload = null;
   if (!hadPreferencesFile) {
     const legacyPatch = await importLegacyFiles(userDataDir);
     if (Object.keys(legacyPatch).length > 0) {
@@ -118,7 +118,7 @@ app.whenReady().then(async () => {
     await preferences.update({
       meta: { installedVersion: app.getVersion(), firstRunAt: new Date().toISOString() },
     });
-    firstRunPayload = { type: install.type, version: app.getVersion() };
+    pendingFirstRun = { type: install.type, version: app.getVersion() };
   }
 
   preferences.subscribe((evt) => {
@@ -128,12 +128,6 @@ app.whenReady().then(async () => {
   });
 
   createWindow();
-
-  mainWindow.webContents.once('did-finish-load', () => {
-    if (firstRunPayload) {
-      mainWindow.webContents.send('first-run', firstRunPayload);
-    }
-  });
 
   // Start Zune USB detection
   zuneManager.start();
@@ -538,6 +532,12 @@ ipcMain.handle('fix-extensionless-files', async (event, filePaths) => {
 });
 
 // Preferences IPC
+ipcMain.handle('consume-first-run', async () => {
+  const payload = pendingFirstRun;
+  pendingFirstRun = null;
+  return payload;
+});
+
 ipcMain.handle('preferences-load', async () => {
   const current = preferences.get('');
   if (current !== undefined) return { success: true, preferences: current };

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -11,6 +11,8 @@ const { DeviceCache } = require('./zune/device-cache');
 const { MetadataCache } = require('./metadata-cache.js');
 const musicbrainz = require('./musicbrainz.js');
 const PodcastManager = require('./podcast-manager');
+const preferences = require('./preferences');
+const { detectInstallType, importLegacyFiles } = require('./preferences-migrations');
 
 const execFileAsync = promisify(execFile);
 const ffmpegPath = require('ffmpeg-static');
@@ -91,15 +93,47 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(() => {
-  createWindow();
-
+app.whenReady().then(async () => {
   deviceCache = new DeviceCache(app.getPath('userData'));
   metadataCache = new MetadataCache(app.getPath('userData'));
   zuneManager.metadataCache = metadataCache;
 
   podcastManager = new PodcastManager(app.getPath('userData'));
   podcastManager.cleanupPartialDownloads();
+
+  // Preferences: load, migrate legacy files on first run after upgrade
+  const userDataDir = app.getPath('userData');
+  const install = await detectInstallType(userDataDir);
+  const prefFile = path.join(userDataDir, 'preferences.json');
+  const hadPreferencesFile = await fs.access(prefFile).then(() => true).catch(() => false);
+
+  await preferences.load(userDataDir, { defaultHome: app.getPath('home') });
+
+  let firstRunPayload = null;
+  if (!hadPreferencesFile) {
+    const legacyPatch = await importLegacyFiles(userDataDir);
+    if (Object.keys(legacyPatch).length > 0) {
+      await preferences.update(legacyPatch);
+    }
+    await preferences.update({
+      meta: { installedVersion: app.getVersion(), firstRunAt: new Date().toISOString() },
+    });
+    firstRunPayload = { type: install.type, version: app.getVersion() };
+  }
+
+  preferences.subscribe((evt) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('preferences-changed', evt);
+    }
+  });
+
+  createWindow();
+
+  mainWindow.webContents.once('did-finish-load', () => {
+    if (firstRunPayload) {
+      mainWindow.webContents.send('first-run', firstRunPayload);
+    }
+  });
 
   // Start Zune USB detection
   zuneManager.start();
@@ -501,6 +535,74 @@ ipcMain.handle('fix-extensionless-files', async (event, filePaths) => {
     }
   }
   return { success: true, renamed };
+});
+
+// Preferences IPC
+ipcMain.handle('preferences-load', async () => {
+  const current = preferences.get('');
+  if (current !== undefined) return { success: true, preferences: current };
+  const loaded = await preferences.load(app.getPath('userData'), { defaultHome: app.getPath('home') });
+  return { success: true, preferences: loaded };
+});
+
+ipcMain.handle('preferences-update', async (_evt, patch) => {
+  try {
+    if (patch && patch.library) {
+      for (const cat of ['music', 'videos', 'pictures']) {
+        if (Array.isArray(patch.library[cat]) && patch.library[cat].length === 0) {
+          return { success: false, error: `library.${cat} cannot be empty` };
+        }
+      }
+    }
+    await preferences.update(patch);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('preferences-reset', async (_evt, section) => {
+  try {
+    await preferences.reset(section);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+// Generic folder picker (reused by library / sync / podcasts)
+ipcMain.handle('pick-folder', async (_evt, title) => {
+  const { dialog } = require('electron');
+  const r = await dialog.showOpenDialog(mainWindow, {
+    title: title || 'Choose folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (r.canceled || r.filePaths.length === 0) return { success: false, canceled: true };
+  return { success: true, path: r.filePaths[0] };
+});
+
+ipcMain.handle('get-app-version', async () => app.getVersion());
+
+ipcMain.handle('clear-metadata-cache', async () => {
+  try {
+    if (metadataCache && typeof metadataCache.clear === 'function') {
+      await metadataCache.clear();
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('clear-device-cache', async () => {
+  try {
+    if (deviceCache && typeof deviceCache.clear === 'function') {
+      await deviceCache.clear();
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
 });
 
 ipcMain.handle('pick-pull-destination', async () => {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -99,18 +99,20 @@ app.whenReady().then(async () => {
   metadataCache = new MetadataCache(app.getPath('userData'));
   zuneManager.metadataCache = metadataCache;
 
-  podcastManager = new PodcastManager(app.getPath('userData'), {
-    getDownloadDirectory: () => preferences.get('podcasts.downloadDirectory'),
-  });
-  podcastManager.cleanupPartialDownloads();
-
-  // Preferences: load, migrate legacy files on first run after upgrade
+  // Preferences: load, migrate legacy files on first run after upgrade.
+  // Must happen before podcastManager is constructed so its getDownloadDirectory
+  // injection can read from the loaded store.
   const userDataDir = app.getPath('userData');
   const install = await detectInstallType(userDataDir);
   const prefFile = path.join(userDataDir, 'preferences.json');
   const hadPreferencesFile = await fs.access(prefFile).then(() => true).catch(() => false);
 
   await preferences.load(userDataDir, { defaultHome: app.getPath('home') });
+
+  podcastManager = new PodcastManager(app.getPath('userData'), {
+    getDownloadDirectory: () => preferences.get('podcasts.downloadDirectory'),
+  });
+  podcastManager.cleanupPartialDownloads();
 
   if (!hadPreferencesFile) {
     const legacyPatch = await importLegacyFiles(userDataDir);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -290,6 +290,17 @@ ipcMain.handle('get-special-folders', async () => {
   return result;
 });
 
+ipcMain.handle('open-external', async (_evt, url) => {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return { success: false };
+    await shell.openExternal(url);
+    return { success: true };
+  } catch {
+    return { success: false };
+  }
+});
+
 ipcMain.handle('get-external-volumes', async () => {
   try {
     const volumes = await platform.getExternalVolumes();

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -99,7 +99,9 @@ app.whenReady().then(async () => {
   metadataCache = new MetadataCache(app.getPath('userData'));
   zuneManager.metadataCache = metadataCache;
 
-  podcastManager = new PodcastManager(app.getPath('userData'));
+  podcastManager = new PodcastManager(app.getPath('userData'), {
+    getDownloadDirectory: () => preferences.get('podcasts.downloadDirectory'),
+  });
   podcastManager.cleanupPartialDownloads();
 
   // Preferences: load, migrate legacy files on first run after upgrade
@@ -1144,11 +1146,16 @@ ipcMain.handle('podcast-get-preferences', async () => {
 ipcMain.handle('podcast-pick-download-directory', async () => {
   try {
     const { dialog } = require('electron');
-    const directory = await podcastManager.pickDownloadDirectory(dialog);
-    if (directory) {
-      return { success: true, directory };
+    const r = await dialog.showOpenDialog({
+      title: 'Choose Podcast Download Directory',
+      properties: ['openDirectory', 'createDirectory'],
+      defaultPath: preferences.get('podcasts.downloadDirectory') || undefined,
+    });
+    if (r.canceled || !r.filePaths || r.filePaths.length === 0) {
+      return { success: false, cancelled: true };
     }
-    return { success: false, cancelled: true };
+    await preferences.update({ podcasts: { downloadDirectory: r.filePaths[0] } });
+    return { success: true, directory: r.filePaths[0] };
   } catch (error) {
     return { success: false, error: error.message };
   }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -554,10 +554,7 @@ ipcMain.handle('consume-first-run', async () => {
 });
 
 ipcMain.handle('preferences-load', async () => {
-  const current = preferences.get('');
-  if (current !== undefined) return { success: true, preferences: current };
-  const loaded = await preferences.load(app.getPath('userData'), { defaultHome: app.getPath('home') });
-  return { success: true, preferences: loaded };
+  return { success: true, preferences: preferences.get('') };
 });
 
 ipcMain.handle('preferences-update', async (_evt, patch) => {
@@ -621,14 +618,7 @@ ipcMain.handle('clear-device-cache', async () => {
 });
 
 ipcMain.handle('pick-pull-destination', async () => {
-  const settingsPath = path.join(app.getPath('userData'), 'pull-destination.json');
-  let defaultPath;
-  try {
-    const data = await fs.readFile(settingsPath, 'utf-8');
-    defaultPath = JSON.parse(data).path;
-  } catch {
-    defaultPath = app.getPath('music');
-  }
+  const defaultPath = preferences.get('sync.pullDestination') || app.getPath('music');
 
   const result = await dialog.showOpenDialog(mainWindow, {
     title: 'Choose destination folder',
@@ -641,14 +631,7 @@ ipcMain.handle('pick-pull-destination', async () => {
   }
 
   const chosen = result.filePaths[0];
-
-  // Remember for next time
-  try {
-    await fs.writeFile(settingsPath, JSON.stringify({ path: chosen }));
-  } catch {
-    // Non-critical — just won't remember next time
-  }
-
+  await preferences.update({ sync: { pullDestination: chosen } });
   return { success: true, path: chosen };
 });
 

--- a/src/main/metadata-cache.js
+++ b/src/main/metadata-cache.js
@@ -45,6 +45,15 @@ class MetadataCache {
     await this._load();
     return { ...this.cache };
   }
+
+  async clear() {
+    this.cache = {};
+    try {
+      await fs.writeFile(this.filePath, '{}');
+    } catch (err) {
+      console.error('MetadataCache.clear failed', err);
+    }
+  }
 }
 
 module.exports = { MetadataCache };

--- a/src/main/podcast-manager.js
+++ b/src/main/podcast-manager.js
@@ -6,8 +6,9 @@ const http = require('http');
 const crypto = require('crypto');
 
 class PodcastManager {
-  constructor(userDataPath) {
+  constructor(userDataPath, options = {}) {
     this._userDataPath = userDataPath;
+    this._getDownloadDirectory = (options && options.getDownloadDirectory) || (() => null);
     this._podcastDir = path.join(userDataPath, 'podcasts');
     this._episodesDir = path.join(this._podcastDir, 'episodes');
     this._artworkDir = path.join(this._podcastDir, 'artwork');
@@ -94,7 +95,10 @@ class PodcastManager {
   }
 
   getPreferences() {
-    return { ...this._preferences };
+    return {
+      ...this._preferences,
+      downloadDirectory: this._getDownloadDirectory() || this._preferences.downloadDirectory,
+    };
   }
 
   // --- HTTP fetching ---
@@ -676,15 +680,13 @@ class PodcastManager {
     const result = await dialog.showOpenDialog({
       title: 'Choose Podcast Download Directory',
       properties: ['openDirectory', 'createDirectory'],
-      defaultPath: this._preferences.downloadDirectory || undefined,
+      defaultPath: this._getDownloadDirectory() || this._preferences.downloadDirectory || undefined,
     });
 
     if (result.canceled || !result.filePaths || result.filePaths.length === 0) {
       return null;
     }
 
-    this._preferences.downloadDirectory = result.filePaths[0];
-    this._savePreferences();
     return result.filePaths[0];
   }
 
@@ -697,13 +699,14 @@ class PodcastManager {
     if (!episode) throw new Error('Episode not found');
     if (!episode.enclosureUrl) throw new Error('No download URL for this episode');
 
-    if (!this._preferences.downloadDirectory) {
+    const dir = this._getDownloadDirectory() || this._preferences.downloadDirectory;
+    if (!dir) {
       throw new Error('No download directory set');
     }
 
     // Build destination path: <downloadDir>/<podcast>/<episode>.<ext>
     const podcastDir = path.join(
-      this._preferences.downloadDirectory,
+      dir,
       this._sanitizeFilename(sub.title)
     );
     fs.mkdirSync(podcastDir, { recursive: true });
@@ -931,7 +934,7 @@ class PodcastManager {
   }
 
   cleanupPartialDownloads() {
-    const downloadDir = this._preferences.downloadDirectory;
+    const downloadDir = this._getDownloadDirectory() || this._preferences.downloadDirectory;
     if (!downloadDir) return;
 
     try {

--- a/src/main/preferences-migrations.js
+++ b/src/main/preferences-migrations.js
@@ -1,0 +1,65 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const SIGNAL_FILES = [
+  'pins.json',
+  'pull-destination.json',
+  'now-playing.json',
+  'metadata-cache.json',
+];
+const SIGNAL_DIRS = ['playlists'];
+
+async function exists(p) {
+  try { await fs.access(p); return true; } catch { return false; }
+}
+
+async function dirNotEmpty(p) {
+  try {
+    const entries = await fs.readdir(p);
+    return entries.length > 0;
+  } catch { return false; }
+}
+
+async function detectInstallType(userDataDir) {
+  const signals = [];
+  for (const f of SIGNAL_FILES) {
+    if (await exists(path.join(userDataDir, f))) signals.push(f);
+  }
+  for (const d of SIGNAL_DIRS) {
+    if (await dirNotEmpty(path.join(userDataDir, d))) signals.push(d + '/');
+  }
+  if (await exists(path.join(userDataDir, 'podcasts', 'preferences.json'))) {
+    signals.push('podcasts/preferences.json');
+  }
+  return { type: signals.length > 0 ? 'upgrade' : 'new', signals };
+}
+
+async function readJsonSafe(p) {
+  try {
+    const raw = await fs.readFile(p, 'utf-8');
+    return JSON.parse(raw);
+  } catch { return null; }
+}
+
+async function importLegacyFiles(userDataDir) {
+  const patch = {};
+
+  const pullPath = path.join(userDataDir, 'pull-destination.json');
+  const pull = await readJsonSafe(pullPath);
+  if (pull && typeof pull.path === 'string') {
+    patch.sync = { pullDestination: pull.path };
+    try { await fs.unlink(pullPath); } catch {}
+  }
+
+  const podPath = path.join(userDataDir, 'podcasts', 'preferences.json');
+  const pod = await readJsonSafe(podPath);
+  if (pod && typeof pod.downloadDirectory === 'string') {
+    patch.podcasts = { downloadDirectory: pod.downloadDirectory };
+    // Don't delete — podcast-manager may have other keys in it.
+    // It's refactored in a later task to read from the central store.
+  }
+
+  return patch;
+}
+
+module.exports = { detectInstallType, importLegacyFiles };

--- a/src/main/preferences.js
+++ b/src/main/preferences.js
@@ -1,0 +1,103 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const FILENAME = 'preferences.json';
+const SCHEMA_VERSION = 1;
+
+let state = null;
+let storeDir = null;
+let subscribers = [];
+let writeTimer = null;
+
+function defaultPrefs(defaultHome) {
+  return {
+    version: SCHEMA_VERSION,
+    library: {
+      music: [path.join(defaultHome, 'Music')],
+      videos: [path.join(defaultHome, 'Movies')],
+      pictures: [path.join(defaultHome, 'Pictures')],
+      scanDesktopAndDownloads: false,
+    },
+    sync: { pullDestination: null },
+    podcasts: { downloadDirectory: null },
+    meta: {
+      installedVersion: null,
+      firstRunAt: null,
+      behaviorChangeToastShown: false,
+    },
+  };
+}
+
+function deepMergeDefaults(loaded, defaults) {
+  const out = {};
+  for (const key of Object.keys(defaults)) {
+    const dv = defaults[key];
+    const lv = loaded ? loaded[key] : undefined;
+    if (lv === undefined) {
+      out[key] = dv;
+    } else if (dv && typeof dv === 'object' && !Array.isArray(dv)) {
+      out[key] = deepMergeDefaults(lv, dv);
+    } else {
+      out[key] = lv;
+    }
+  }
+  return out;
+}
+
+async function readFileSafe(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    try { await fs.rename(filePath, filePath + '.bad'); } catch {}
+    return null;
+  }
+}
+
+async function writeNow() {
+  if (!state || !storeDir) return;
+  const filePath = path.join(storeDir, FILENAME);
+  const copy = { ...state };
+  delete copy.__defaultHome;
+  const raw = JSON.stringify(copy, null, 2);
+  const tmp = filePath + '.tmp';
+  await fs.writeFile(tmp, raw);
+  await fs.rename(tmp, filePath);
+}
+
+function scheduleWrite(ms = 200) {
+  if (writeTimer) clearTimeout(writeTimer);
+  writeTimer = setTimeout(() => {
+    writeTimer = null;
+    writeNow().catch((err) => console.error('preferences: write failed', err));
+  }, ms);
+}
+
+async function load(userDataDir, { defaultHome }) {
+  storeDir = userDataDir;
+  const filePath = path.join(storeDir, FILENAME);
+  const loaded = await readFileSafe(filePath);
+  const defaults = defaultPrefs(defaultHome);
+  if (loaded === null) {
+    state = defaults;
+    await writeNow();
+  } else {
+    state = deepMergeDefaults(loaded, defaults);
+  }
+  state.__defaultHome = defaultHome;
+  return state;
+}
+
+function get(dotPath) {
+  if (!state) return undefined;
+  const parts = dotPath.split('.');
+  let cur = state;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+module.exports = { load, get, SCHEMA_VERSION };

--- a/src/main/preferences.js
+++ b/src/main/preferences.js
@@ -100,4 +100,67 @@ function get(dotPath) {
   return cur;
 }
 
-module.exports = { load, get, SCHEMA_VERSION };
+function collectLeafPaths(patch, prefix = '') {
+  const out = [];
+  for (const key of Object.keys(patch)) {
+    const v = patch[key];
+    const p = prefix ? `${prefix}.${key}` : key;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out.push(...collectLeafPaths(v, p));
+    } else {
+      out.push({ path: p, newValue: v });
+    }
+  }
+  return out;
+}
+
+function deepMerge(target, src) {
+  for (const key of Object.keys(src)) {
+    const sv = src[key];
+    if (sv && typeof sv === 'object' && !Array.isArray(sv)) {
+      if (!target[key] || typeof target[key] !== 'object') target[key] = {};
+      deepMerge(target[key], sv);
+    } else {
+      target[key] = sv;
+    }
+  }
+}
+
+async function update(patch) {
+  if (!state) throw new Error('preferences not loaded');
+  const events = collectLeafPaths(patch);
+  deepMerge(state, patch);
+  await writeNow();
+  for (const evt of events) {
+    for (const cb of subscribers) {
+      try { cb(evt); } catch (err) { console.error('preferences subscriber threw', err); }
+    }
+  }
+}
+
+async function reset(section) {
+  if (!state || !storeDir) throw new Error('preferences not loaded');
+  const home = state.__defaultHome || require('node:os').homedir();
+  const defaults = defaultPrefs(home);
+  if (section) {
+    state[section] = defaults[section];
+  } else {
+    state = defaults;
+    state.__defaultHome = home;
+  }
+  await writeNow();
+}
+
+function subscribe(cb) {
+  subscribers.push(cb);
+  return () => { subscribers = subscribers.filter((s) => s !== cb); };
+}
+
+function _resetModule() {
+  state = null;
+  storeDir = null;
+  subscribers = [];
+  if (writeTimer) { clearTimeout(writeTimer); writeTimer = null; }
+}
+
+module.exports = { load, get, update, reset, subscribe, SCHEMA_VERSION, _resetModule };

--- a/src/main/preferences.js
+++ b/src/main/preferences.js
@@ -82,6 +82,11 @@ async function load(userDataDir, { defaultHome }) {
 
 function get(dotPath) {
   if (!state) return undefined;
+  if (dotPath === undefined || dotPath === null || dotPath === '') {
+    const copy = { ...state };
+    delete copy.__defaultHome;
+    return copy;
+  }
   const parts = dotPath.split('.');
   let cur = state;
   for (const p of parts) {

--- a/src/main/preferences.js
+++ b/src/main/preferences.js
@@ -7,7 +7,6 @@ const SCHEMA_VERSION = 1;
 let state = null;
 let storeDir = null;
 let subscribers = [];
-let writeTimer = null;
 
 function defaultPrefs(defaultHome) {
   return {
@@ -64,14 +63,6 @@ async function writeNow() {
   const tmp = filePath + '.tmp';
   await fs.writeFile(tmp, raw);
   await fs.rename(tmp, filePath);
-}
-
-function scheduleWrite(ms = 200) {
-  if (writeTimer) clearTimeout(writeTimer);
-  writeTimer = setTimeout(() => {
-    writeTimer = null;
-    writeNow().catch((err) => console.error('preferences: write failed', err));
-  }, ms);
 }
 
 async function load(userDataDir, { defaultHome }) {
@@ -160,7 +151,6 @@ function _resetModule() {
   state = null;
   storeDir = null;
   subscribers = [];
-  if (writeTimer) { clearTimeout(writeTimer); writeTimer = null; }
 }
 
 module.exports = { load, get, update, reset, subscribe, SCHEMA_VERSION, _resetModule };

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -179,12 +179,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return handler;
   },
   offPreferencesChanged: (h) => ipcRenderer.removeListener('preferences-changed', h),
-  onFirstRun: (cb) => {
-    const handler = (_e, payload) => cb(payload);
-    ipcRenderer.on('first-run', handler);
-    return handler;
-  },
-  offFirstRun: (h) => ipcRenderer.removeListener('first-run', h),
+  consumeFirstRun: () => ipcRenderer.invoke('consume-first-run'),
   pickFolder: (title) => ipcRenderer.invoke('pick-folder', title),
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -184,4 +184,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
   clearDeviceCache: () => ipcRenderer.invoke('clear-device-cache'),
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,4 +1,5 @@
 const { contextBridge, ipcRenderer, webUtils } = require('electron');
+const pathUtils = require('../shared/path-utils');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getDirectoryContents: (path) => ipcRenderer.invoke('get-directory-contents', path),
@@ -190,3 +191,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
   clearDeviceCache: () => ipcRenderer.invoke('clear-device-cache'),
 });
+
+contextBridge.exposeInMainWorld('pathUtils', pathUtils);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -1,5 +1,4 @@
 const { contextBridge, ipcRenderer, webUtils } = require('electron');
-const pathUtils = require('../shared/path-utils');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getDirectoryContents: (path) => ipcRenderer.invoke('get-directory-contents', path),
@@ -191,5 +190,3 @@ contextBridge.exposeInMainWorld('electronAPI', {
   clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
   clearDeviceCache: () => ipcRenderer.invoke('clear-device-cache'),
 });
-
-contextBridge.exposeInMainWorld('pathUtils', pathUtils);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -168,4 +168,25 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return handler;
   },
   offPodcastImportProgress: (handler) => ipcRenderer.removeListener('podcast-import-progress', handler),
+
+  // Preferences, settings, and first-run
+  preferencesLoad: () => ipcRenderer.invoke('preferences-load'),
+  preferencesUpdate: (patch) => ipcRenderer.invoke('preferences-update', patch),
+  preferencesReset: (section) => ipcRenderer.invoke('preferences-reset', section),
+  onPreferencesChanged: (cb) => {
+    const handler = (_e, evt) => cb(evt);
+    ipcRenderer.on('preferences-changed', handler);
+    return handler;
+  },
+  offPreferencesChanged: (h) => ipcRenderer.removeListener('preferences-changed', h),
+  onFirstRun: (cb) => {
+    const handler = (_e, payload) => cb(payload);
+    ipcRenderer.on('first-run', handler);
+    return handler;
+  },
+  offFirstRun: (h) => ipcRenderer.removeListener('first-run', h),
+  pickFolder: (title) => ipcRenderer.invoke('pick-folder', title),
+  getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+  clearMetadataCache: () => ipcRenderer.invoke('clear-metadata-cache'),
+  clearDeviceCache: () => ipcRenderer.invoke('clear-device-cache'),
 });

--- a/src/main/zune/device-cache.js
+++ b/src/main/zune/device-cache.js
@@ -41,6 +41,19 @@ class DeviceCache {
       // File may not exist
     }
   }
+
+  async clear() {
+    try {
+      const entries = await fs.readdir(this.cacheDir);
+      await Promise.all(
+        entries
+          .filter(e => e.endsWith('.json'))
+          .map(e => fs.unlink(path.join(this.cacheDir, e)).catch(() => {}))
+      );
+    } catch {
+      // cacheDir may not exist yet — nothing to clear
+    }
+  }
 }
 
 module.exports = { DeviceCache };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -68,6 +68,10 @@
                             <span class="menu-text">applications</span>
                             <span class="menu-subs">all</span>
                         </button>
+                        <button class="menu-item" data-category="settings">
+                            <span class="menu-text">settings</span>
+                            <span class="menu-subs">preferences</span>
+                        </button>
                     </nav>
                 </div>
             </div>
@@ -414,6 +418,7 @@
     <script src="../assets/js/virtual-scroller.js"></script>
     <script src="../assets/js/podcast-renderer.js"></script>
     <script src="../assets/js/boot-splash.js"></script>
+    <script src="../assets/js/settings-view.js"></script>
     <script src="../assets/js/renderer.js"></script>
     <script src="../assets/js/test-data-generator.js"></script>
 </body>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -405,6 +405,7 @@
         </div>
     </div>
 
+    <script src="../shared/path-utils.js"></script>
     <script src="../assets/js/audio-player.js"></script>
     <script src="../assets/js/virtual-scroller.js"></script>
     <script src="../assets/js/podcast-renderer.js"></script>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,6 +8,10 @@
     <link rel="stylesheet" href="../assets/css/styles.css">
 </head>
 <body>
+    <div class="boot-splash" id="boot-splash" style="display:none">
+      <div class="boot-splash-bar" id="boot-splash-bar"></div>
+      <div class="boot-splash-message" id="boot-splash-message"></div>
+    </div>
     <div class="zune-container">
         <!-- Custom title bar (Windows only, hidden on macOS via CSS) -->
         <div class="title-bar" id="title-bar">
@@ -409,6 +413,7 @@
     <script src="../assets/js/audio-player.js"></script>
     <script src="../assets/js/virtual-scroller.js"></script>
     <script src="../assets/js/podcast-renderer.js"></script>
+    <script src="../assets/js/boot-splash.js"></script>
     <script src="../assets/js/renderer.js"></script>
     <script src="../assets/js/test-data-generator.js"></script>
 </body>

--- a/src/shared/path-utils.js
+++ b/src/shared/path-utils.js
@@ -24,9 +24,16 @@ function computeRemovedPaths(oldList, newList) {
   return oldList.filter((p) => !newSet.has(normalize(p)));
 }
 
-module.exports = {
+const pathUtils = {
   isUnderPrefix,
   isUnderAnyPrefix,
   computeAddedPaths,
   computeRemovedPaths,
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = pathUtils;
+}
+if (typeof window !== 'undefined') {
+  window.pathUtils = pathUtils;
+}

--- a/src/shared/path-utils.js
+++ b/src/shared/path-utils.js
@@ -1,0 +1,32 @@
+function normalize(p) {
+  if (!p) return p;
+  return p.endsWith('/') || p.endsWith('\\') ? p.slice(0, -1) : p;
+}
+
+function isUnderPrefix(p, prefix) {
+  const np = normalize(p);
+  const npr = normalize(prefix);
+  if (np === npr) return true;
+  return np.startsWith(npr + '/') || np.startsWith(npr + '\\');
+}
+
+function isUnderAnyPrefix(p, prefixes) {
+  return prefixes.some((pref) => isUnderPrefix(p, pref));
+}
+
+function computeAddedPaths(oldList, newList) {
+  const oldSet = new Set(oldList.map(normalize));
+  return newList.filter((p) => !oldSet.has(normalize(p)));
+}
+
+function computeRemovedPaths(oldList, newList) {
+  const newSet = new Set(newList.map(normalize));
+  return oldList.filter((p) => !newSet.has(normalize(p)));
+}
+
+module.exports = {
+  isUnderPrefix,
+  isUnderAnyPrefix,
+  computeAddedPaths,
+  computeRemovedPaths,
+};

--- a/tests/path-utils.test.js
+++ b/tests/path-utils.test.js
@@ -1,0 +1,48 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isUnderPrefix,
+  isUnderAnyPrefix,
+  computeAddedPaths,
+  computeRemovedPaths,
+} = require('../src/shared/path-utils');
+
+test('isUnderPrefix: exact match is under itself', () => {
+  assert.equal(isUnderPrefix('/a/b', '/a/b'), true);
+});
+
+test('isUnderPrefix: sub-path is under prefix', () => {
+  assert.equal(isUnderPrefix('/a/b/c', '/a/b'), true);
+});
+
+test('isUnderPrefix: sibling is not under', () => {
+  assert.equal(isUnderPrefix('/a/bc', '/a/b'), false);
+});
+
+test('isUnderPrefix: parent is not under child', () => {
+  assert.equal(isUnderPrefix('/a', '/a/b'), false);
+});
+
+test('isUnderPrefix: trailing slash on prefix normalized', () => {
+  assert.equal(isUnderPrefix('/a/b/c', '/a/b/'), true);
+});
+
+test('isUnderAnyPrefix: matches one of several', () => {
+  assert.equal(isUnderAnyPrefix('/music/rock', ['/other', '/music']), true);
+});
+
+test('isUnderAnyPrefix: empty list returns false', () => {
+  assert.equal(isUnderAnyPrefix('/a', []), false);
+});
+
+test('computeAddedPaths: returns new list minus old', () => {
+  assert.deepEqual(computeAddedPaths(['/a'], ['/a', '/b']), ['/b']);
+});
+
+test('computeRemovedPaths: returns old list minus new', () => {
+  assert.deepEqual(computeRemovedPaths(['/a', '/b'], ['/a']), ['/b']);
+});
+
+test('computeAddedPaths: no changes returns empty', () => {
+  assert.deepEqual(computeAddedPaths(['/a'], ['/a']), []);
+});

--- a/tests/preferences-migrations.test.js
+++ b/tests/preferences-migrations.test.js
@@ -1,0 +1,72 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+function fresh() {
+  delete require.cache[require.resolve('../src/main/preferences-migrations')];
+  return require('../src/main/preferences-migrations');
+}
+
+let tmpDir;
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prefs-mig-'));
+});
+
+test('detectInstallType: empty userData is new', async () => {
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'new');
+});
+
+test('detectInstallType: pins.json present is upgrade', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pins.json'), '[]');
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'upgrade');
+  assert.deepEqual(r.signals, ['pins.json']);
+});
+
+test('detectInstallType: pull-destination plus playlists is upgrade', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), '{}');
+  await fs.mkdir(path.join(tmpDir, 'playlists'));
+  await fs.writeFile(path.join(tmpDir, 'playlists', 'a.json'), '{}');
+  const m = fresh();
+  const r = await m.detectInstallType(tmpDir);
+  assert.equal(r.type, 'upgrade');
+  assert.deepEqual(r.signals.sort(), ['playlists/', 'pull-destination.json']);
+});
+
+test('importLegacyFiles: pull-destination becomes sync.pullDestination and file is deleted', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), JSON.stringify({ path: '/my/pulls' }));
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync.pullDestination, '/my/pulls');
+  await assert.rejects(fs.access(path.join(tmpDir, 'pull-destination.json')));
+});
+
+test('importLegacyFiles: no pull-destination yields empty sync patch', async () => {
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync, undefined);
+});
+
+test('importLegacyFiles: corrupt pull-destination is left alone, no patch', async () => {
+  await fs.writeFile(path.join(tmpDir, 'pull-destination.json'), '{corrupt');
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.sync, undefined);
+  await fs.access(path.join(tmpDir, 'pull-destination.json'));
+});
+
+test('importLegacyFiles: podcast preferences downloadDirectory becomes podcasts.downloadDirectory', async () => {
+  await fs.mkdir(path.join(tmpDir, 'podcasts'));
+  await fs.writeFile(
+    path.join(tmpDir, 'podcasts', 'preferences.json'),
+    JSON.stringify({ downloadDirectory: '/pods/dl' })
+  );
+  const m = fresh();
+  const patch = await m.importLegacyFiles(tmpDir);
+  assert.equal(patch.podcasts.downloadDirectory, '/pods/dl');
+});

--- a/tests/preferences.test.js
+++ b/tests/preferences.test.js
@@ -1,0 +1,70 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+function freshModule() {
+  delete require.cache[require.resolve('../src/main/preferences')];
+  return require('../src/main/preferences');
+}
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'prefs-test-'));
+});
+
+test('load: missing file writes defaults', async () => {
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.equal(store.version, 1);
+  assert.deepEqual(store.library.music, ['/Users/test/Music']);
+  assert.deepEqual(store.library.videos, ['/Users/test/Movies']);
+  assert.deepEqual(store.library.pictures, ['/Users/test/Pictures']);
+  assert.equal(store.library.scanDesktopAndDownloads, false);
+
+  const raw = await fs.readFile(path.join(tmpDir, 'preferences.json'), 'utf-8');
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.version, 1);
+});
+
+test('load: valid existing file returned as-is', async () => {
+  await fs.writeFile(
+    path.join(tmpDir, 'preferences.json'),
+    JSON.stringify({
+      version: 1,
+      library: { music: ['/a'], videos: ['/b'], pictures: ['/c'], scanDesktopAndDownloads: true },
+      sync: { pullDestination: '/pull' },
+      podcasts: { downloadDirectory: '/pods' },
+      meta: { installedVersion: '1.4.0', firstRunAt: '2026-01-01T00:00:00Z' },
+    })
+  );
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/a']);
+  assert.equal(store.library.scanDesktopAndDownloads, true);
+  assert.equal(store.sync.pullDestination, '/pull');
+});
+
+test('load: missing nested keys get defaults merged in', async () => {
+  await fs.writeFile(
+    path.join(tmpDir, 'preferences.json'),
+    JSON.stringify({ version: 1, library: { music: ['/a'] } })
+  );
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/a']);
+  assert.deepEqual(store.library.videos, ['/Users/test/Movies']);
+  assert.equal(store.library.scanDesktopAndDownloads, false);
+  assert.equal(store.sync.pullDestination, null);
+});
+
+test('get: returns value at dot path', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(prefs.get('library.music'), ['/Users/test/Music']);
+  assert.equal(prefs.get('library.scanDesktopAndDownloads'), false);
+  assert.equal(prefs.get('sync.pullDestination'), null);
+  assert.equal(prefs.get('nonexistent.path'), undefined);
+});

--- a/tests/preferences.test.js
+++ b/tests/preferences.test.js
@@ -68,3 +68,67 @@ test('get: returns value at dot path', async () => {
   assert.equal(prefs.get('sync.pullDestination'), null);
   assert.equal(prefs.get('nonexistent.path'), undefined);
 });
+
+test('update: deep merges patch and persists', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({ library: { music: ['/new'] } });
+  assert.deepEqual(prefs.get('library.music'), ['/new']);
+  assert.deepEqual(prefs.get('library.videos'), ['/Users/test/Movies']);
+  const fresh = freshModule();
+  const store = await fresh.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.deepEqual(store.library.music, ['/new']);
+});
+
+test('subscribe: fires on update with path and newValue', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  const events = [];
+  prefs.subscribe((evt) => events.push(evt));
+  await prefs.update({ library: { scanDesktopAndDownloads: true } });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].path, 'library.scanDesktopAndDownloads');
+  assert.equal(events[0].newValue, true);
+});
+
+test('subscribe: fires once per leaf touched', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  const events = [];
+  prefs.subscribe((evt) => events.push(evt));
+  await prefs.update({
+    library: { music: ['/x'] },
+    sync: { pullDestination: '/y' },
+  });
+  const paths = events.map((e) => e.path).sort();
+  assert.deepEqual(paths, ['library.music', 'sync.pullDestination']);
+});
+
+test('reset: section reset restores defaults for that section only', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({
+    library: { music: ['/x'] },
+    sync: { pullDestination: '/y' },
+  });
+  await prefs.reset('library');
+  assert.deepEqual(prefs.get('library.music'), ['/Users/test/Music']);
+  assert.equal(prefs.get('sync.pullDestination'), '/y');
+});
+
+test('reset: full reset with no argument', async () => {
+  const prefs = freshModule();
+  await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  await prefs.update({ sync: { pullDestination: '/y' } });
+  await prefs.reset();
+  assert.equal(prefs.get('sync.pullDestination'), null);
+});
+
+test('load: malformed JSON is preserved as .bad and defaults used', async () => {
+  await fs.writeFile(path.join(tmpDir, 'preferences.json'), '{not json');
+  const prefs = freshModule();
+  const store = await prefs.load(tmpDir, { defaultHome: '/Users/test' });
+  assert.equal(store.version, 1);
+  const bad = await fs.readFile(path.join(tmpDir, 'preferences.json.bad'), 'utf-8');
+  assert.equal(bad, '{not json');
+});

--- a/tests/sanity.test.js
+++ b/tests/sanity.test.js
@@ -1,0 +1,6 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('sanity: node:test runs', () => {
+  assert.equal(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary

- **Closes #12** — users can now configure where music, video, and picture files are scanned from, plus a toggle for the legacy "also scan Desktop & Downloads" behavior (off by default for new installs).
- **Adds a Settings panorama section** in the Zune HD aesthetic — giant clipped hero header at every drill level, white left-aligned list rows that drill in (library → music folders → folder leaf), back button anchored to the corner.
- **Unified preferences store** — a single schema-versioned `preferences.json` in `userData/`, replacing scattered `pull-destination.json` and the podcast download-directory split. Existing installs are migrated transparently on first launch.
- **Zune-style boot/update splash** — first launch after install/upgrade plays the iconic vertical bar growing from the bottom with a pink → orange → teal → blue gradient. ~5s. Existing users also see a one-time toast announcing the Desktop/Downloads default change with instructions to re-enable.

## What's in v1

- **Library** — per-category folder lists (Music / Videos / Pictures), each pre-populated with the OS default; add via native folder picker, drill into a folder for "reveal in finder" / "remove from library"; last-folder-in-category guarded both in UI and at IPC. Toggle for Desktop/Downloads scanning.
- **Sync** — pull destination (absorbs legacy `pull-destination.json`).
- **Podcasts** — download directory (now read from central preferences via injected getter; podcast-manager refactored).
- **Data** — clear metadata cache / clear device cache actions.
- **About** — version, github link, credits.

## Out of scope (parked)

Skins / accent colors, scan-behavior toggles (extensionless, depth, hidden), preferences export/import, MusicBrainz toggle.

## Architecture highlights

- `src/main/preferences.js` — singleton with `load`/`get`/`update`/`subscribe`/`reset`. Schema-versioned (v1). Atomic writes via `.tmp` + rename. Malformed JSON preserved as `.bad` and defaults restored. Deep-merges loaded data with current schema defaults so missing keys are filled without overwriting present ones.
- `src/main/preferences-migrations.js` — install-type detection (looks for `pins.json`, `playlists/`, `pull-destination.json`, etc.) + best-effort legacy-file imports.
- `src/shared/path-utils.js` — pure helpers for prefix matching and list deltas. Dual-export (CommonJS for `node:test`, `window.pathUtils` for the renderer via `<script>` tag — preload can't `require()` arbitrary modules under `sandbox: true`).
- `src/assets/js/settings-view.js` — drill-stack navigation. Each page is a `{ title, buildItems() }` descriptor; items are `nav | action | toggle | info | placeholder`.
- `_handleLibraryPrefChange` in renderer.js — computes add/remove deltas against the in-memory library and avoids re-scanning unchanged folders. Correctly handles nested configurations (removing `/Music` keeps `/Music/Rock` tracks if Rock is independently configured).

## Tests

- `node:test` infrastructure added (`npm test`).
- 28 unit tests across preferences, migrations, and path-utils. All pass.
- Manual acceptance covers fresh install, upgrade migration, and all issue #12 scenarios.

## Behavior change to flag

Desktop & Downloads scanning is now off by default. Existing installs see a one-time toast on the upgrade boot:

> *"desktop & downloads are no longer scanned by default. re-enable in settings → library."*

The flag is persisted in `preferences.meta.behaviorChangeToastShown` so it never repeats.

## Test plan

- [x] `npm test` passes (28/28)
- [x] Fresh install: boot splash, no behavior-change toast, only OS-default folders scanned
- [x] Upgrade: boot splash + toast, legacy `pull-destination.json` absorbed and removed, podcast download directory preserved
- [x] Add a custom music folder → tracks appear after rescan
- [x] Remove a folder while another is configured → its tracks disappear, others remain
- [x] Last-folder removal disabled in UI and rejected by IPC
- [x] Nested case: `/Music/Rock` survives when `/Music` is removed
- [x] Toggle Desktop/Downloads scanning on/off
- [x] Sync, podcasts, data (cache clears), about leaves all functional
- [x] Pull destination flow uses central preferences (no resurrection of `pull-destination.json`)
- [x] Existing pins, playlists, Zune sync, podcast download/playback unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)